### PR TITLE
Bump version (v0.0.1-rc3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # CHANGELOG
 
+## [v0.0.1-rc3](https://github.com/NubeIO/rubix-os/tree/v0.0.1-rc3) (2023-06-05)
+
+- Move ROS-related installation in BIOS part
+- Upgrade snapshot APIs after integrating them into the ROS
+- Fix: Delete APIs response for rubix-assist APIs
+- Fix: copy only enabled systemctl files in snapshot creation
+- Fix: snapshot unable to stop the service files
+- Attach OpenVPN IP on returning group's hosts
+
 ## [v0.0.1-rc2](https://github.com/NubeIO/rubix-os/tree/v0.0.1-rc2) (2023-05-31)
 
 - Includes views and teams


### PR DESCRIPTION
### Summary

- Move ROS-related installation in BIOS part
- Upgrade snapshot APIs after integrating them into the ROS
- Fix: Delete APIs response for rubix-assist APIs
- Fix: copy only enabled systemctl files in snapshot creation
- Fix: snapshot unable to stop the service files
- Attach OpenVPN IP on returning group's hosts