### PR TITLE
Add read and write api endpoint for host points

### DIFF
--- a/router/router.go
+++ b/router/router.go
@@ -1022,5 +1022,10 @@ func Create(db *database.GormDatabase, conf *config.Configuration, scheduler *go
 			}
 		}
 	}
+	hostPointApiRoutes := engine.Group("/api/host_points")
+	{
+		hostPointApiRoutes.GET("/:uuid", pointHandler.GetPointByHost)
+		hostPointApiRoutes.PATCH("/write/:uuid", pointHandler.WritePointByHost)
+	}
 	return engine
 }

--- a/src/client/point.go
+++ b/src/client/point.go
@@ -94,3 +94,15 @@ func (inst *FlowClient) GetPointWithParent(uuid string) (*interfaces.PointWithPa
 	}
 	return resp.Result().(*interfaces.PointWithParent), nil
 }
+
+func (inst *FlowClient) WritePoint(uuid string, body *model.PointWriter) (*model.Point, error) {
+	resp, err := nresty.FormatRestyResponse(inst.client.R().
+		SetBody(body).
+		SetResult(&model.Point{}).
+		SetPathParams(map[string]string{"uuid": uuid}).
+		Patch("/api/points/write/{uuid}"))
+	if err != nil {
+		return nil, err
+	}
+	return resp.Result().(*model.Point), nil
+}


### PR DESCRIPTION
Resolves: #42
### Summary:
- Added read and write api endpoints for host points. Examples:
  - GET `api/host_points/:uuid -H "host-uuid: <uuid>"` or  `api/host_points/:uuid -H "host-name: <name>"`
  - PATCH `api/host_points/:uuid -H "host-uuid: <uuid>"` or  `api/host_points/:uuid -H "host-name: <name>"`
    ```
    -d {
        "priority": {
            "_16": 0
         }
      }

    ```