### PR TITLE
Bump version (v0.0.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # CHANGELOG
 
+## [v0.0.3](https://github.com/NubeIO/rubix-os/tree/v0.0.3) (2023-06-21)
+
+- Improvements: role base auth and auth error message
+- Add history_enable flag in network and device
+- Remove auto-mapping options from the schema
+- Remove the message model
+- Add device info fields to the location
+- Use global_uuid.txt instead device_info.json
+
 ## [v0.0.2](https://github.com/NubeIO/rubix-os/tree/v0.0.2) (2023-06-13)
 
 - Rework on history


### PR DESCRIPTION
### Summary

- Improvements: role base auth and auth error message
- Add history_enable flag in network and device
- Remove auto-mapping options from the schema
- Remove the message model
- Add device info fields to the location
- Use global_uuid.txt instead device_info.json