### PR TITLE
updates tag and meta-tag db update functions

### DIFF
--- a/database/device_funcs.go
+++ b/database/device_funcs.go
@@ -125,9 +125,9 @@ func (d *GormDatabase) DeleteDeviceByName(networkName string, deviceName string,
 func (d *GormDatabase) GetDevicesTagsForPostgresSync() ([]*interfaces.DeviceTagForPostgresSync, error) {
 	var deviceTagsForPostgresModel []*interfaces.DeviceTagForPostgresSync
 	query := d.DB.Table("devices_tags").
-		Select("devices.source_uuid AS device_uuid, devices_tags.tag_tag AS tag").
-		Joins("INNER JOIN devices ON devices.uuid = devices_tags.device_uuid").
-		Where("IFNULL(devices.source_uuid,'') != ''").
+		Select("points.device_uuid AS device_uuid, devices_tags.tag_tag AS tag").
+		Joins("INNER JOIN points ON points.device_uuid = devices_tags.device_uuid").
+		Where("IFNULL(points.device_uuid,'') != ''").
 		Scan(&deviceTagsForPostgresModel)
 	if query.Error != nil {
 		return nil, query.Error

--- a/database/devicemetatag.go
+++ b/database/devicemetatag.go
@@ -49,9 +49,9 @@ func (d *GormDatabase) GetDeviceMetaTags() ([]*model.DeviceMetaTag, error) {
 func (d *GormDatabase) GetDevicesMetaTagsForPostgresSync() ([]*model.DeviceMetaTag, error) {
 	var deviceMetaTagsModel []*model.DeviceMetaTag
 	query := d.DB.Table("device_meta_tags").
-		Select("devices.source_uuid AS device_uuid, device_meta_tags.key, device_meta_tags.value").
-		Joins("INNER JOIN devices ON devices.uuid = device_meta_tags.device_uuid").
-		Where("IFNULL(devices.source_uuid,'') != ''").
+		Select("points.device_uuid AS device_uuid, device_meta_tags.key, device_meta_tags.value").
+		Joins("INNER JOIN points ON points.device_uuid = device_meta_tags.device_uuid").
+		Where("IFNULL(points.device_uuid,'') != ''").
 		Scan(&deviceMetaTagsModel)
 	if query.Error != nil {
 		return nil, query.Error

--- a/database/network_funcs.go
+++ b/database/network_funcs.go
@@ -168,9 +168,9 @@ func (d *GormDatabase) GetPublishPointList() ([]*interfaces.PublishPointList, er
 func (d *GormDatabase) GetNetworksTagsForPostgresSync() ([]*interfaces.NetworkTagForPostgresSync, error) {
 	var networkTagsForPostgresModel []*interfaces.NetworkTagForPostgresSync
 	query := d.DB.Table("networks_tags").
-		Select("networks.source_uuid AS network_uuid, networks_tags.tag_tag AS tag").
-		Joins("INNER JOIN networks ON networks.uuid = networks_tags.network_uuid").
-		Where("IFNULL(networks.source_uuid,'') != ''").
+		Select("points.network_uuid AS network_uuid, networks_tags.tag_tag AS tag").
+		Joins("INNER JOIN points ON points.network_uuid = networks_tags.network_uuid").
+		Where("IFNULL(points.network_uuid,'') != ''").
 		Scan(&networkTagsForPostgresModel)
 	if query.Error != nil {
 		return nil, query.Error

--- a/database/networkmetatag.go
+++ b/database/networkmetatag.go
@@ -49,9 +49,9 @@ func (d *GormDatabase) GetNetworkMetaTags() ([]*model.NetworkMetaTag, error) {
 func (d *GormDatabase) GetNetworksMetaTagsForPostgresSync() ([]*model.NetworkMetaTag, error) {
 	var networkMetaTagsModel []*model.NetworkMetaTag
 	query := d.DB.Table("network_meta_tags").
-		Select("networks.source_uuid AS network_uuid, network_meta_tags.key, network_meta_tags.value").
-		Joins("INNER JOIN networks ON networks.uuid = network_meta_tags.network_uuid").
-		Where("IFNULL(networks.source_uuid,'') != ''").
+		Select("points.network_uuid AS network_uuid, network_meta_tags.key, network_meta_tags.value").
+		Joins("INNER JOIN points ON points.network_uuid = network_meta_tags.network_uuid").
+		Where("IFNULL(points.network_uuid,'') != ''").
 		Scan(&networkMetaTagsModel)
 	if query.Error != nil {
 		return nil, query.Error

--- a/database/point_funcs.go
+++ b/database/point_funcs.go
@@ -111,9 +111,9 @@ func (d *GormDatabase) GetPointsForPostgresSync() ([]*interfaces.PointForPostgre
 func (d *GormDatabase) GetPointsTagsForPostgresSync() ([]*interfaces.PointTagForPostgresSync, error) {
 	var pointTagsForPostgresModel []*interfaces.PointTagForPostgresSync
 	query := d.DB.Table("points_tags").
-		Select("points.source_uuid AS point_uuid, points_tags.tag_tag AS tag").
+		Select("points.uuid AS point_uuid, points_tags.tag_tag AS tag").
 		Joins("INNER JOIN points ON points.uuid = points_tags.point_uuid").
-		Where("IFNULL(points.source_uuid,'') != ''").
+		Where("IFNULL(points.uuid,'') != ''").
 		Scan(&pointTagsForPostgresModel)
 	if query.Error != nil {
 		return nil, query.Error


### PR DESCRIPTION
@RaiBnod @enjuthulung 

I was working with the `postgres` plugin today, and noticed that the point meta-tags weren't updating to the PG DB.  I dug through the plugin code, and found that there were still MANY references to `devices` and `networks` tables, that no longer exist in the RubixOS schema.  

I have pushed some changes to the tag/meta-tag update functions.  Could you guys please review these changes, and make the rest of the updates to the `dbhandler` functions that deal with querying data from the PG DB.  

For example: 
These joins don't look neccesary anymore: https://github.com/NubeIO/rubix-os/blob/55a61b81a6f886c5b3d3726a8b6e52bd852ad949/database/point_funcs.go#L99

There are many others too. 