### PR TITLE
Maintain shareable pollqueue for modules

### DIFF
--- a/module/dbhelper.go
+++ b/module/dbhelper.go
@@ -50,6 +50,8 @@ func (*dbHelper) Get(path, uuid, args string) ([]byte, error) {
 		out, err = database.GlobalGormDatabase.GetNetworkByName(name, apiArgs)
 	} else if path == "plugin_by_path" {
 		out, err = database.GlobalGormDatabase.GetPluginByPath(uuid)
+	} else if path == "plugin_by_id" {
+		out, err = database.GlobalGormDatabase.GetPlugin(uuid)
 	} else {
 		return nil, errors.New("not found")
 	}

--- a/module/shared/grpcmarshal.go
+++ b/module/shared/grpcmarshal.go
@@ -40,6 +40,7 @@ type Marshaller interface {
 	GetSchedules() ([]*model.Schedule, error)
 	UpdateScheduleAllProps(uuid string, body *model.Schedule) (*model.Schedule, error)
 
+	GetPlugin(pluginUUID, args string) (*model.PluginConf, error)
 	GetPluginByPath(name, args string) (*model.PluginConf, error)
 	SetErrorsForAllDevicesOnNetwork(networkUUID, message, messageLevel, messageCode string, doPoints bool) error
 	ClearErrorsForAllDevicesOnNetwork(networkUUID string, doPoints bool) error
@@ -368,6 +369,19 @@ func (g *GRPCMarshaller) UpdateScheduleAllProps(uuid string, body *model.Schedul
 		return nil, err
 	}
 	return schedule, nil
+}
+
+func (g *GRPCMarshaller) GetPlugin(pluginUUID, args string) (*model.PluginConf, error) {
+	res, err := g.DbHelper.Get("plugin_by_id", pluginUUID, args)
+	if err != nil {
+		return nil, err
+	}
+	var pluginConf *model.PluginConf
+	err = json.Unmarshal(res, &pluginConf)
+	if err != nil {
+		return nil, err
+	}
+	return pluginConf, nil
 }
 
 func (g *GRPCMarshaller) GetPluginByPath(name, args string) (*model.PluginConf, error) {

--- a/module/shared/pollqueue/config.go
+++ b/module/shared/pollqueue/config.go
@@ -1,0 +1,6 @@
+package pollqueue
+
+type Config struct {
+	EnablePolling bool   `yaml:"enable_polling"`
+	LogLevel      string `yaml:"log_level"`
+}

--- a/module/shared/pollqueue/constants.go
+++ b/module/shared/pollqueue/constants.go
@@ -1,0 +1,10 @@
+package pollqueue
+
+type PollRetryType string
+
+const (
+	NORMAL_RETRY    PollRetryType = "normal-retry"
+	IMMEDIATE_RETRY PollRetryType = "immediate-retry"
+	DELAYED_RETRY   PollRetryType = "delayed-retry"
+	NEVER_RETRY     PollRetryType = "never-retry"
+)

--- a/module/shared/pollqueue/poll_manager.go
+++ b/module/shared/pollqueue/poll_manager.go
@@ -1,0 +1,348 @@
+package pollqueue
+
+import (
+	"container/heap"
+	"fmt"
+	"github.com/NubeIO/nubeio-rubix-lib-models-go/pkg/v1/model"
+	"github.com/NubeIO/rubix-os/module/shared"
+	"github.com/NubeIO/rubix-os/utils/boolean"
+	"github.com/NubeIO/rubix-os/utils/float"
+	"time"
+)
+
+// REFS:
+//  - GOLANG HEAP https://pkg.go.dev/container/heap
+//  - Worker Queue tutorial: https://www.opsdash.com/blog/job-queues-in-go.html
+
+type NetworkPollManager struct {
+	Config     *Config
+	Marshaller shared.Marshaller
+
+	Enable                    bool
+	MaxPollRate               time.Duration
+	PollQueue                 *NetworkPriorityPollQueue
+	PluginQueueUnloader       *QueueUnloader
+	StatsCalcTimer            *time.Ticker
+	PortUnavailableTimeout    *time.Timer
+	QueueCheckerTimer         *time.Ticker
+	QueueCheckerCancelChannel chan bool
+
+	// References
+	FFNetworkUUID string
+	NetworkName   string
+	FFPluginUUID  string
+	PluginName    string
+
+	// Statistics
+	MaxPollExecuteTimeSecs        float64       // time in seconds for polling to complete (poll response time, doesn't include the time in queue).
+	AveragePollExecuteTimeSecs    float64       // time in seconds for polling to complete (poll response time, doesn't include the time in queue).
+	MinPollExecuteTimeSecs        float64       // time in seconds for polling to complete (poll response time, doesn't include the time in queue).
+	TotalPollQueueLength          int64         // number of polling points in the current queue.
+	TotalStandbyPointsLength      int64         // number of polling points in the standby list.
+	TotalPointsOutForPolling      int64         // number of points currently out for polling (currently being handled by the protocol plugin).
+	ASAPPriorityPollQueueLength   int64         // number of ASAP priority polling points in the current queue.
+	HighPriorityPollQueueLength   int64         // number of High priority polling points in the current queue.
+	NormalPriorityPollQueueLength int64         // number of Normal priority polling points in the current queue.
+	LowPriorityPollQueueLength    int64         // number of Low priority polling points in the current queue.
+	ASAPPriorityAveragePollTime   float64       // average time in seconds between ASAP priority polling point added to current queue, and polling complete.
+	HighPriorityAveragePollTime   float64       // average time in seconds between High priority polling point added to current queue, and polling complete.
+	NormalPriorityAveragePollTime float64       // average time in seconds between Normal priority polling point added to current queue, and polling complete.
+	LowPriorityAveragePollTime    float64       // average time in seconds between Low priority polling point added to current queue, and polling complete.
+	TotalPollCount                int64         // total number of polls completed.
+	ASAPPriorityPollCount         int64         // total number of ASAP priority polls completed.
+	HighPriorityPollCount         int64         // total number of High priority polls completed.
+	NormalPriorityPollCount       int64         // total number of Normal priority polls completed.
+	LowPriorityPollCount          int64         // total number of Low priority polls completed.
+	ASAPPriorityPollCountForAvg   int64         // number of poll times included in avg polling time for ASAP priority (some are excluded because they have been modified while in the queue).
+	HighPriorityPollCountForAvg   int64         // number of poll times included in avg polling time for High priority (some are excluded because they have been modified while in the queue).
+	NormalPriorityPollCountForAvg int64         // number of poll times included in avg polling time for Normal priority (some are excluded because they have been modified while in the queue).
+	LowPriorityPollCountForAvg    int64         // number of poll times included in avg polling time for Low priority (some are excluded because they have been modified while in the queue).
+	ASAPPriorityMaxCycleTime      time.Duration // threshold setting for triggering a lockup alert for ASAP priority.
+	HighPriorityMaxCycleTime      time.Duration // threshold setting for triggering a lockup alert for High priority.
+	NormalPriorityMaxCycleTime    time.Duration // threshold setting for triggering a lockup alert for Normal priority.
+	LowPriorityMaxCycleTime       time.Duration // threshold setting for triggering a lockup alert for Low priority.
+	ASAPPriorityLockupAlert       bool          // alert if poll time has exceeded the ASAPPriorityMaxCycleTime
+	HighPriorityLockupAlert       bool          // alert if poll time has exceeded the HighPriorityMaxCycleTime
+	NormalPriorityLockupAlert     bool          // alert if poll time has exceeded the NormalPriorityMaxCycleTime
+	LowPriorityLockupAlert        bool          // alert if poll time has exceeded the LowPriorityMaxCycleTime
+	PollingStartTimeUnix          int64         // unix time (seconds) at polling start time.  Used for calculating Busy Time.
+	BusyTime                      float64       // percent of the time that the plugin is actively polling.
+	EnabledTime                   float64       // time in seconds that the statistics have been running for.
+	PortUnavailableTime           float64       // time in seconds that the serial port has been unavailable.
+	PortUnavailableStartTime      int64         // unix time (seconds) when port became unavailable.  Used for calculating downtime.
+}
+
+func (pm *NetworkPollManager) StartPolling() {
+	if !pm.Enable {
+		pm.Enable = true
+		pm.RebuildPollingQueue()
+		pm.StartQueueUnloader()
+	} else if pm.PluginQueueUnloader == nil {
+		pm.StartQueueUnloader()
+	}
+	// Also start the Queue Checker
+	pm.StartQueueCheckerAndStats()
+	pm.StartPollingStatistics()
+}
+
+func (pm *NetworkPollManager) StopPolling() {
+	pm.Enable = false
+	// pm.EmptyQueue()
+
+	pm.StopQueueUnloader()
+	// TODO: STOP ANY QUEUE LOADERS
+	for _, pp := range pm.PollQueue.StandbyPollingPoints.PriorityQueue {
+		if pp != nil && pp.RepollTimer != nil {
+			pp.RepollTimer.Stop()
+		}
+	}
+	pm.PollQueue.EmptyQueue()
+	if pm.QueueCheckerTimer != nil && pm.QueueCheckerCancelChannel != nil {
+		pm.StopQueueCheckerAndStats()
+	}
+}
+
+func (pm *NetworkPollManager) PausePolling() { // POLLING SHOULD NOT BE PAUSED FOR LONG OR THE QUEUE WILL BECOME TOO LONG
+	pm.pollQueueDebugMsg("PausePolling()")
+	pm.Enable = false
+	var nextPP *PollingPoint = nil
+	if pm.PluginQueueUnloader.NextPollPoint != nil {
+		nextPP = pm.PluginQueueUnloader.NextPollPoint
+		pm.PollQueue.AddPollingPoint(nextPP) // add the next point back into the queue
+	}
+	pm.StopQueueUnloader()
+}
+
+func (pm *NetworkPollManager) UnpausePolling() {
+	pm.pollQueueDebugMsg("UnpausePolling()")
+	pm.Enable = true
+	pm.PortUnavailableTimeout = nil
+	pm.StartQueueUnloader()
+}
+
+func (pm *NetworkPollManager) EmptyQueue() {
+	pm.StopQueueUnloader()
+	pm.PollQueue.EmptyQueue()
+}
+
+func (pm *NetworkPollManager) ReAddDevicePoints(devUUID string) { // This is triggered by a user who wants to update the device poll times for standby points
+	// var arg api.Args
+	// arg.WithPoints = true
+	dev, err := pm.Marshaller.GetDevice(devUUID, "with_points=true")
+	if dev == nil || err != nil {
+		pm.pollQueueErrorMsg("ReAddDevicePoints(): cannot find device ", devUUID)
+		return
+	}
+	pm.PollQueue.RemovePollingPointByDeviceUUID(devUUID)
+	for _, pnt := range dev.Points {
+		if boolean.IsTrue(pnt.Enable) {
+			pp := NewPollingPoint(pnt.UUID, pnt.DeviceUUID, dev.NetworkUUID, pm.FFPluginUUID)
+			pp.PollPriority = pnt.PollPriority
+			pm.PollQueue.AddPollingPoint(pp)
+		}
+	}
+}
+
+func NewPollManager(conf *Config, marshaller shared.Marshaller, ffNetworkUUID, ffNetworkName, ffPluginUUID, pluginName string, maxPollRate float64) *NetworkPollManager {
+	// Make the main priority polling queue
+	queue := make([]*PollingPoint, 0)
+	pq := &PriorityPollQueue{queue}
+	heap.Init(pq)                        // Init needs to be called on the main PriorityQueue so that it is maintained by PollingPriority.
+	refQueue := make([]*PollingPoint, 0) // Make the reference slice that contains points that are not in the current polling queue.
+	rq := &PriorityPollQueue{refQueue}
+	heap.Init(rq)                                // Init needs to be called on the main PriorityQueue so that it is maintained by PollingPriority.
+	outstandingQueue := make([]*PollingPoint, 0) // Make the reference slice that contains points that are not in the current polling queue.
+	opq := &PriorityPollQueue{outstandingQueue}
+	heap.Init(opq)
+	adl := make([]string, 0)
+	pqu := &QueueUnloader{nil, nil, nil}
+	puwp := make(map[string]bool)
+	npq := &NetworkPriorityPollQueue{conf, pq, rq, opq, puwp, pqu, ffPluginUUID, ffNetworkUUID, adl}
+	pm := new(NetworkPollManager)
+	pm.Config = conf
+	pm.PollQueue = npq
+	pm.PluginQueueUnloader = pqu
+	pm.Marshaller = marshaller
+	pm.MaxPollRate, _ = time.ParseDuration(fmt.Sprintf("%fs", maxPollRate))
+	pm.FFNetworkUUID = ffNetworkUUID
+	pm.NetworkName = ffNetworkName
+	pm.FFPluginUUID = ffPluginUUID
+	pm.PluginName = pluginName
+	pm.ASAPPriorityMaxCycleTime, _ = time.ParseDuration("2m")
+	pm.HighPriorityMaxCycleTime, _ = time.ParseDuration("5m")
+	pm.NormalPriorityMaxCycleTime, _ = time.ParseDuration("15m")
+	pm.LowPriorityMaxCycleTime, _ = time.ParseDuration("60m")
+	return pm
+}
+
+func (pm *NetworkPollManager) GetPollRateDuration(rate model.PollRate, deviceUUID string) time.Duration {
+	// var arg api.Args
+	var duration time.Duration
+
+	if pm.Marshaller != nil {
+		device, err := pm.Marshaller.GetDevice(deviceUUID, "")
+		if err != nil {
+			pm.pollQueueDebugMsg(fmt.Sprintf("NetworkPollManager.GetPollRateDuration(): couldn't find device %s", deviceUUID))
+			return 30 * time.Second
+		}
+		// Get durations from device
+		switch rate {
+		case model.RATE_FAST:
+			fastRateDuration, _ := time.ParseDuration(fmt.Sprintf("%fs", float.NonNil(device.FastPollRate)))
+			if fastRateDuration <= 100*time.Millisecond {
+				duration = 10 * time.Second
+			} else {
+				duration = fastRateDuration
+			}
+
+		case model.RATE_NORMAL:
+			normalRateDuration, _ := time.ParseDuration(fmt.Sprintf("%fs", float.NonNil(device.NormalPollRate)))
+			if normalRateDuration <= 500*time.Millisecond {
+				duration = 30 * time.Second
+			} else {
+				duration = normalRateDuration
+			}
+
+		case model.RATE_SLOW:
+			slowRateDuration, _ := time.ParseDuration(fmt.Sprintf("%fs", float.NonNil(device.SlowPollRate)))
+			if slowRateDuration <= 1*time.Second {
+				duration = 120 * time.Second
+			} else {
+				duration = slowRateDuration
+			}
+
+		default:
+			pm.pollQueueDebugMsg("GetPollRateDuration(): UNKNOWN")
+			normalRateDuration, _ := time.ParseDuration(fmt.Sprintf("%fs", float.NonNil(device.SlowPollRate)))
+			if normalRateDuration <= 500*time.Millisecond {
+				duration = 30 * time.Second
+			} else {
+				duration = normalRateDuration
+			}
+		}
+	} else {
+		pm.pollQueueErrorMsg("GetPollRateDuration(): NetworkPollManager marshaller is undefined")
+		// use default durations
+		duration = 30 * time.Second
+	}
+
+	// pm.pollQueueDebugMsg("GetPollRateDuration() device poll times: ", device.FastPollRate, device.NormalPollRate, device.SlowPollRate)
+	if duration.Milliseconds() <= 100 {
+		duration = 30 * time.Second
+		pm.pollQueueErrorMsg("NetworkPollManager.GetPollRateDuration: invalid PollRate duration. Set to 30 seconds")
+
+	}
+	return duration
+}
+
+func (pm *NetworkPollManager) PollingFinished(pp *PollingPoint, pollStartTime time.Time, writeSuccess, readSuccess, actualPoll, pollingWasNotRequired bool, retryType PollRetryType, callback func(pp *PollingPoint, writeSuccess bool, readSuccess bool, pollTimeSecs float64, pointUpdate, resetToConfiguredPriority bool, retryType PollRetryType, actualPoll, pollingWasNotRequired, justToReAdd bool)) {
+	pollEndTime := time.Now()
+	pollDuration := pollEndTime.Sub(pollStartTime)
+	pollTimeSecs := pollDuration.Seconds()
+	callback(pp, writeSuccess, readSuccess, pollTimeSecs, false, true, retryType, actualPoll, pollingWasNotRequired, false) // (pm *NetworkPollManager) PollingPointCompleteNotification(pp *PollingPoint, writeSuccess, readSuccess bool)
+}
+
+func (pm *NetworkPollManager) PollQueueErrorChecking() {
+	pm.pollQueueDebugMsg("NetworkPollManager.PollQueueErrorChecking")
+	net, err := pm.Marshaller.GetNetwork(pm.FFNetworkUUID, "with_devices=true&&with_points=true") // api.Args{WithDevices: true, WithPoints: true}
+	if net == nil || err != nil {
+		pm.pollQueueErrorMsg("NetworkPollManager.PollQueueErrorChecking: Network Not Found")
+		return
+	}
+	if boolean.IsFalse(net.Enable) { // If network isn't enabled, there should be no points in the polling queues
+		if pm.PollQueue.PriorityQueue.Len() > 0 {
+			pm.PollQueue.PriorityQueue.EmptyQueue()
+			pm.pollQueueErrorMsg("NetworkPollManager.PollQueueErrorChecking: Found PollingPoints in PriorityQueue of a disabled network")
+		}
+		if pm.PollQueue.StandbyPollingPoints.Len() > 0 {
+			pm.PollQueue.StandbyPollingPoints.EmptyQueue()
+			pm.pollQueueErrorMsg("NetworkPollManager.PollQueueErrorChecking: Found PollingPoints in StandbyPollingPoints of a disabled network")
+		}
+		if pm.PollQueue.OutstandingPollingPoints.Len() > 0 {
+			pm.PollQueue.OutstandingPollingPoints.EmptyQueue()
+			pm.pollQueueErrorMsg("NetworkPollManager.PollQueueErrorChecking: Found PollingPoints in OutstandingPollingPoints of a disabled network")
+		}
+	}
+	for _, dev := range net.Devices {
+		deviceExistsInQueue := pm.PollQueue.CheckIfActiveDevicesListIncludes(dev.UUID)
+		if boolean.IsFalse(net.Enable) || boolean.IsFalse(dev.Enable) {
+			if deviceExistsInQueue {
+				pm.pollQueueErrorMsg("NetworkPollManager.PollQueueErrorChecking: Device UUID exist in Poll Queues for a disabled device")
+				pm.PollQueue.RemovePollingPointByDeviceUUID(dev.UUID)
+				continue
+			}
+		}
+		if boolean.IsTrue(net.Enable) && boolean.IsTrue(dev.Enable) && !deviceExistsInQueue {
+			pm.pollQueueErrorMsg("NetworkPollManager.PollQueueErrorChecking: Device UUID doesn't exist in active devices list")
+		}
+		if dev.Points != nil {
+			for _, pnt := range dev.Points {
+				if pnt != nil {
+					if boolean.IsFalse(net.Enable) || boolean.IsFalse(dev.Enable) || boolean.IsFalse(pnt.Enable) {
+						pp, _ := pm.PollQueue.GetPollingPointByPointUUID(pnt.UUID)
+						if pp != nil {
+							pm.pollQueueErrorMsg("NetworkPollManager.PollQueueErrorChecking: Found disabled point in poll queue")
+							pm.PollQueue.RemovePollingPointByPointUUID(pnt.UUID)
+						}
+						continue
+					}
+					if boolean.IsTrue(net.Enable) && boolean.IsTrue(dev.Enable) && boolean.IsTrue(pnt.Enable) {
+						pp, err := pm.PollQueue.GetPollingPointByPointUUID(pnt.UUID)
+						if pp == nil || err != nil {
+							pm.pollQueueErrorMsg("NetworkPollManager.PollQueueErrorChecking: Polling point doesn't exist for point ", pnt.Name)
+							pp = NewPollingPoint(pnt.UUID, pnt.DeviceUUID, dev.NetworkUUID, pm.FFPluginUUID)
+							pm.PollingPointCompleteNotification(pp, false, false, 0, true, true, NORMAL_RETRY, false, false, true) // This will perform the queue re-add actions based on Point WriteMode.
+						}
+						continue
+					}
+				}
+			}
+		}
+	}
+}
+
+func (pm *NetworkPollManager) StartQueueCheckerAndStats() {
+	period := 30 * time.Second
+	if pm.QueueCheckerTimer != nil {
+		pm.QueueCheckerTimer.Stop()
+	}
+	pm.QueueCheckerTimer = nil
+	if pm.QueueCheckerCancelChannel != nil {
+		pm.QueueCheckerCancelChannel <- true
+	}
+	pm.QueueCheckerCancelChannel = nil
+	ticker := time.NewTicker(period)
+	pm.QueueCheckerTimer = ticker
+	done := make(chan bool)
+	pm.QueueCheckerCancelChannel = done
+	go func() {
+		for {
+			select {
+			case <-done:
+				return
+			case <-ticker.C:
+				// pm.pollQueueDebugMsg("RELOAD QUEUE TICKER")
+				pm.PollQueueErrorChecking()
+				pm.PrintPollQueueStatistics()
+			}
+		}
+	}()
+}
+
+func (pm *NetworkPollManager) StopQueueCheckerAndStats() {
+	pm.QueueCheckerTimer.Stop()
+	pm.QueueCheckerTimer = nil
+	pm.QueueCheckerCancelChannel <- true
+	pm.QueueCheckerCancelChannel = nil
+}
+
+func (pm *NetworkPollManager) PortUnavailable() {
+	pm.PortUnavailableStartTime = time.Now().Unix()
+	pm.PausePolling()
+}
+
+func (pm *NetworkPollManager) PortAvailable() {
+	pm.PartialPollStatsUpdate()
+	pm.PrintPollQueueStatistics()
+	pm.UnpausePolling()
+}

--- a/module/shared/pollqueue/poll_queue.go
+++ b/module/shared/pollqueue/poll_queue.go
@@ -1,0 +1,395 @@
+package pollqueue
+
+import (
+	"container/heap"
+	"errors"
+	"fmt"
+	"github.com/NubeIO/nubeio-rubix-lib-models-go/pkg/v1/model"
+	"github.com/NubeIO/rubix-os/utils/nstring"
+	log "github.com/sirupsen/logrus"
+	"time"
+)
+
+// REFS:
+//  - GOLANG HEAP https://pkg.go.dev/container/heap
+//  - Worker Queue tutorial: https://www.opsdash.com/blog/job-queues-in-go.html
+
+type NetworkPriorityPollQueue struct {
+	Config                    *Config
+	PriorityQueue             *PriorityPollQueue // This is the queue that is polling points are drawn from
+	StandbyPollingPoints      *PriorityPollQueue // This is a slice that contains polling points that are not in the active polling queue, it is mostly a reference so that we can periodically find out if any points have been dropped from polling.
+	OutstandingPollingPoints  *PriorityPollQueue // this is a slice that contains polling points that are currently out for polling.
+	PointsUpdatedWhilePolling map[string]bool    // UUIDs of points that have been updated while they were out for polling.  bool is true if the point needs to be written ASAP
+	QueueUnloader             *QueueUnloader
+	FFPluginUUID              string
+	FFNetworkUUID             string
+	ActiveDevicesList         []string // UUIDs of devices that have points in the queue
+}
+
+func (nq *NetworkPriorityPollQueue) AddPollingPoint(pp *PollingPoint) bool {
+	nq.pollQueueDebugMsg("NetworkPriorityPollQueue AddPollingPoint(): ", pp.FFPointUUID)
+	if pp.FFNetworkUUID != nq.FFNetworkUUID {
+		nq.pollQueueErrorMsg(fmt.Sprintf("NetworkPriorityPollQueue.AddPollingPoint: PollingPoint FFNetworkUUID does not match the queue FFNetworkUUID. FFNetworkUUID: %s  FFPointUUID: %s \n", nq.FFNetworkUUID, pp.FFPointUUID))
+		if pp.LockupAlertTimer != nil {
+			pp.LockupAlertTimer.Stop()
+		}
+		return false
+	}
+	if nq.PriorityQueue.GetPollingPointIndexByPointUUID(pp.FFPointUUID) != -1 {
+		log.Errorf("NetworkPriorityPollQueue.AddPollingPoint: PollingPoint %s already exists in polling queue. \n", pp.FFPointUUID)
+		if pp.LockupAlertTimer != nil {
+			pp.LockupAlertTimer.Stop()
+		}
+		return false
+	}
+	if nq.StandbyPollingPoints.GetPollingPointIndexByPointUUID(pp.FFPointUUID) != -1 {
+		// point exists in the StandbyPollingPoints list, remove it and add immediately.
+		nq.RemovePollingPointByPointUUID(pp.FFPointUUID)
+	}
+	if nq.OutstandingPollingPoints.GetPollingPointIndexByPointUUID(pp.FFPointUUID) != -1 {
+		_, ok := nq.PointsUpdatedWhilePolling[pp.FFPointUUID]
+		if !ok {
+			nq.PointsUpdatedWhilePolling[pp.FFPointUUID] = false
+		}
+		return true
+	}
+
+	pp.QueueEntryTime = time.Now().Unix()
+	success := nq.PriorityQueue.AddPollingPoint(pp)
+	if !success {
+		// log.Errorf("NetworkPriorityPollQueue.AddPollingPoint: point already exists in poll queue. FFNetworkUUID: %s  FFPointUUID: %s \n", nq.FFNetworkUUID, pp.FFPointUUID)
+		return false
+	}
+	nq.AddDeviceToActiveDevicesList(pp.FFDeviceUUID)
+	return true
+}
+
+func (nq *NetworkPriorityPollQueue) RemovePollingPointByPointUUID(pointUUID string) (pp *PollingPoint, success bool) {
+	nq.pollQueueDebugMsg("RemovePollingPointByPointUUID(): ", pointUUID)
+	pp = nil
+	if nq.QueueUnloader != nil && nq.QueueUnloader.NextPollPoint != nil && nq.QueueUnloader.NextPollPoint.FFPointUUID == pointUUID {
+		pp = nq.QueueUnloader.NextPollPoint
+		if nq.QueueUnloader.NextPollPoint.LockupAlertTimer != nil {
+			nq.QueueUnloader.NextPollPoint.LockupAlertTimer.Stop()
+		}
+		nq.QueueUnloader.NextPollPoint = nil
+	}
+	ppPQ, _ := nq.PriorityQueue.RemovePollingPointByPointUUID(pointUUID)
+	if ppPQ != nil {
+		nq.pollQueueDebugMsg("RemovePollingPointByPointUUID(): Point is in the PriorityQueue")
+		return ppPQ, true
+	}
+	ppSPQ, _ := nq.StandbyPollingPoints.RemovePollingPointByPointUUID(pointUUID)
+	if ppSPQ != nil {
+		nq.pollQueueDebugMsg("RemovePollingPointByPointUUID(): Point is in the StandbyPollingPoints Queue")
+		return ppSPQ, true
+	}
+	if pp != nil {
+		return pp, true
+	} else if ppPQ != nil {
+		return ppPQ, true
+	} else if ppSPQ != nil {
+		return ppSPQ, true
+	}
+	return pp, false
+}
+
+func (nq *NetworkPriorityPollQueue) RemovePollingPointByDeviceUUID(deviceUUID string) bool {
+	nq.pollQueueDebugMsg("RemovePollingPointByDeviceUUID(): ", deviceUUID)
+	nq.PriorityQueue.RemovePollingPointByDeviceUUID(deviceUUID)
+	nq.StandbyPollingPoints.RemovePollingPointByDeviceUUID(deviceUUID)
+	nq.OutstandingPollingPoints.RemovePollingPointByDeviceUUID(deviceUUID)
+	nq.RemoveDeviceFromActiveDevicesList(deviceUUID)
+	return true
+}
+func (nq *NetworkPriorityPollQueue) UpdatePollingPointByPointUUID(pointUUID string, newPriority model.PollPriority) bool {
+	nq.PriorityQueue.UpdatePollingPointByPointUUID(pointUUID, newPriority)
+	nq.StandbyPollingPoints.UpdatePollingPointByPointUUID(pointUUID, newPriority)
+	return true
+}
+func (nq *NetworkPriorityPollQueue) GetPollingPointByPointUUID(pointUUID string) (pp *PollingPoint, err error) {
+	nq.pollQueueDebugMsg("NetworkPriorityPollQueue GetPollingPointByPointUUID(): ", pointUUID)
+	pp = nil
+	if nq.QueueUnloader != nil && nq.QueueUnloader.NextPollPoint != nil && nq.QueueUnloader.NextPollPoint.FFPointUUID == pointUUID {
+		pp = nq.QueueUnloader.NextPollPoint
+		return pp, nil
+	}
+	pollQueueIndex := nq.PriorityQueue.GetPollingPointIndexByPointUUID(pointUUID)
+	if pollQueueIndex != -1 {
+		return nq.PriorityQueue.PriorityQueue[pollQueueIndex], nil
+	}
+	standbyIndex := nq.StandbyPollingPoints.GetPollingPointIndexByPointUUID(pointUUID)
+	if standbyIndex != -1 {
+		return nq.StandbyPollingPoints.PriorityQueue[standbyIndex], nil
+	}
+	outstandingIndex := nq.OutstandingPollingPoints.GetPollingPointIndexByPointUUID(pointUUID)
+	if outstandingIndex != -1 {
+		return nq.OutstandingPollingPoints.PriorityQueue[outstandingIndex], nil
+	}
+
+	return nil, errors.New(fmt.Sprint("couldn't find point: ", pointUUID))
+}
+
+func (nq *NetworkPriorityPollQueue) GetNextPollingPoint() (*PollingPoint, error) {
+	pp, err := nq.PriorityQueue.GetNextPollingPoint()
+	if err != nil {
+		// nq.pollQueueDebugMsg(fmt.Sprintf("NetworkPriorityPollQueue.GetNextPollingPoint: no PollingPoints in queue. FFNetworkUUID: %s \n", nq.FFNetworkUUID))
+		return nil, errors.New(fmt.Sprintf("NetworkPriorityPollQueue.GetNextPollingPoint: no PollingPoints in queue"))
+	}
+	return pp, nil
+}
+func (nq *NetworkPriorityPollQueue) Start() {
+	// nq.PriorityQueue.Start()
+}
+func (nq *NetworkPriorityPollQueue) Stop() {
+	// nq.PriorityQueue.Stop()
+	nq.EmptyQueue()
+}
+func (nq *NetworkPriorityPollQueue) EmptyQueue() {
+	nq.PriorityQueue.EmptyQueue()
+	refQueue := make([]*PollingPoint, 0)
+	rq := &PriorityPollQueue{refQueue}
+	nq.StandbyPollingPoints = rq
+	outstandingQueue := make([]*PollingPoint, 0)
+	opq := &PriorityPollQueue{outstandingQueue}
+	nq.StandbyPollingPoints = opq
+}
+func (nq *NetworkPriorityPollQueue) CheckIfActiveDevicesListIncludes(devUUID string) bool {
+	for _, dev := range nq.ActiveDevicesList {
+		if dev == devUUID {
+			return true
+		}
+	}
+	return false
+}
+func (nq *NetworkPriorityPollQueue) AddDeviceToActiveDevicesList(devUUID string) bool {
+	for _, dev := range nq.ActiveDevicesList {
+		if dev == devUUID {
+			return false
+		}
+	}
+	nq.ActiveDevicesList = append(nq.ActiveDevicesList, devUUID)
+	return true
+}
+func (nq *NetworkPriorityPollQueue) RemoveDeviceFromActiveDevicesList(devUUID string) bool {
+	for index, dev := range nq.ActiveDevicesList {
+		if dev == devUUID {
+			// remove the devUUID from ActiveDevicesList
+			nq.ActiveDevicesList[index] = nq.ActiveDevicesList[len(nq.ActiveDevicesList)-1]
+			nq.ActiveDevicesList = nq.ActiveDevicesList[:len(nq.ActiveDevicesList)-1]
+			return true
+		}
+	}
+	return false
+}
+func (nq *NetworkPriorityPollQueue) CheckPollingQueueForDevUUID(devUUID string) bool {
+	for _, pp := range nq.PriorityQueue.PriorityQueue {
+		if pp.FFDeviceUUID == devUUID {
+			return true
+		}
+	}
+	for _, pp := range nq.StandbyPollingPoints.PriorityQueue {
+		if pp.FFDeviceUUID == devUUID {
+			return true
+		}
+	}
+	for _, pp := range nq.OutstandingPollingPoints.PriorityQueue {
+		if pp.FFDeviceUUID == devUUID {
+			return true
+		}
+	}
+	return false
+}
+
+// THIS IS THE BASE PriorityPollQueue Type and defines the base methods used to implement the `heap` library.  https://pkg.go.dev/container/heap
+type PriorityPollQueue struct {
+	// Enable        bool
+	PriorityQueue []*PollingPoint
+}
+
+func (q *PriorityPollQueue) Len() int { return len(q.PriorityQueue) }
+func (q *PriorityPollQueue) Less(i, j int) bool {
+	if len(q.PriorityQueue) <= i && len(q.PriorityQueue) <= j {
+		return false
+	}
+	iPriority := q.PriorityQueue[i].PollPriority
+	iPriorityNum := 0
+	switch iPriority {
+	case model.PRIORITY_ASAP:
+		iPriorityNum = 0
+	case model.PRIORITY_HIGH:
+		iPriorityNum = 1
+	case model.PRIORITY_NORMAL:
+		iPriorityNum = 2
+	case model.PRIORITY_LOW:
+		iPriorityNum = 3
+	}
+	jPriority := q.PriorityQueue[j].PollPriority
+	jPriorityNum := 0
+	switch jPriority {
+	case model.PRIORITY_ASAP:
+		jPriorityNum = 0
+	case model.PRIORITY_HIGH:
+		jPriorityNum = 1
+	case model.PRIORITY_NORMAL:
+		jPriorityNum = 2
+	case model.PRIORITY_LOW:
+		jPriorityNum = 3
+	}
+
+	if iPriorityNum < jPriorityNum {
+		return true
+	}
+	if iPriorityNum > jPriorityNum {
+		return false
+	}
+
+	iTimestamp := q.PriorityQueue[i].QueueEntryTime
+	jTimestamp := q.PriorityQueue[j].QueueEntryTime
+	return iTimestamp < jTimestamp
+}
+func (q *PriorityPollQueue) Swap(i, j int) {
+	q.PriorityQueue[i], q.PriorityQueue[j] = q.PriorityQueue[j], q.PriorityQueue[i]
+}
+func (q *PriorityPollQueue) Push(x interface{}) {
+	item := x.(*PollingPoint)
+	q.PriorityQueue = append(q.PriorityQueue, item)
+}
+func (q *PriorityPollQueue) Pop() interface{} {
+	old := q.PriorityQueue
+	n := len(old)
+	item := old[n-1]
+	old[n-1] = nil // avoid memory leak
+	q.PriorityQueue = old[0 : n-1]
+	return item
+}
+func (q *PriorityPollQueue) GetPollingPointIndexByPointUUID(pointUUID string) int {
+	for index, pp := range q.PriorityQueue {
+		if pp != nil { // i got a nil pointer issue here and it crashed FF @Marc to look (aidan)
+			if pp.FFPointUUID == pointUUID {
+				return index
+			}
+		}
+	}
+	return -1
+}
+func (q *PriorityPollQueue) RemovePollingPointByPointUUID(pointUUID string) (pp *PollingPoint, success bool) {
+	pp = nil
+	index := q.GetPollingPointIndexByPointUUID(pointUUID)
+	if index >= 0 {
+		pp = heap.Remove(q, index).(*PollingPoint)
+		if pp != nil {
+			// pollQueueDebugMsg("RemovePollingPointByPointUUID() pp: %+v\n", pp)
+		}
+		if pp.RepollTimer != nil {
+			pp.RepollTimer.Stop()
+		}
+		if pp.LockupAlertTimer != nil {
+			pp.LockupAlertTimer.Stop()
+		}
+		return pp, true
+	}
+	return pp, false
+}
+func (q *PriorityPollQueue) RemovePollingPointByDeviceUUID(deviceUUID string) bool {
+	index := 0
+	for index < q.Len() {
+		pp := q.PriorityQueue[index]
+		if pp.FFDeviceUUID == deviceUUID {
+			if pp.RepollTimer != nil {
+				pp.RepollTimer.Stop()
+			}
+			heap.Remove(q, index)
+			if pp.LockupAlertTimer != nil {
+				pp.LockupAlertTimer.Stop()
+			}
+		} else {
+			index++
+		}
+	}
+	return true
+}
+func (q *PriorityPollQueue) RemovePollingPointByNetworkUUID(networkUUID string) bool {
+	index := 0
+	for index < q.Len() {
+		pp := q.PriorityQueue[index]
+		if pp.FFNetworkUUID == networkUUID {
+			if pp.RepollTimer != nil {
+				pp.RepollTimer.Stop()
+			}
+			heap.Remove(q, index)
+			if pp.LockupAlertTimer != nil {
+				pp.LockupAlertTimer.Stop()
+			}
+		} else {
+			index++
+		}
+	}
+	return true
+}
+func (q *PriorityPollQueue) AddPollingPoint(pp *PollingPoint) bool {
+	index := q.GetPollingPointIndexByPointUUID(pp.FFPointUUID)
+	if index == -1 {
+		heap.Push(q, pp)
+		return true
+	}
+	return false
+}
+func (q *PriorityPollQueue) UpdatePollingPointByPointUUID(pointUUID string, newPriority model.PollPriority) bool {
+	index := q.GetPollingPointIndexByPointUUID(pointUUID)
+	if index >= 0 {
+		q.PriorityQueue[index].PollPriority = newPriority
+		heap.Fix(q, index)
+		return true
+	}
+	return false
+}
+
+// func (q *PriorityPollQueue) Start() { q.Enable = true }  //TODO: add queue startup code
+// func (q *PriorityPollQueue) Stop()  { q.Enable = false } //TODO: add queue stop code
+func (q *PriorityPollQueue) EmptyQueue() {
+	for q.Len() > 0 {
+		heap.Pop(q)
+	}
+}
+func (q *PriorityPollQueue) GetNextPollingPoint() (*PollingPoint, error) {
+	if q.Len() > 0 {
+		pp := heap.Pop(q).(*PollingPoint)
+		return pp, nil
+	}
+	return nil, errors.New("PriorityPollQueue is not enabled")
+}
+
+type PollingPoint struct {
+	PollPriority     model.PollPriority
+	FFPointUUID      string
+	FFDeviceUUID     string
+	FFNetworkUUID    string
+	FFPluginUUID     string
+	RepollTimer      *time.Timer
+	QueueEntryTime   int64
+	LockupAlertTimer *time.Timer
+}
+
+func NewPollingPoint(ffPointUUID, ffDeviceUUID, ffNetworkUUID, ffPluginUUID string) *PollingPoint {
+	pp := &PollingPoint{model.PRIORITY_NORMAL, ffPointUUID, ffDeviceUUID, ffNetworkUUID, ffPluginUUID, nil, 0, nil}
+	// WHATEVER FUNCTION CALLS NewPollingPoint NEEDS TO SET THE PRIORITY
+	return pp
+}
+
+func NewPollingPointWithPriority(ffPointUUID, ffDeviceUUID, ffNetworkUUID, ffPluginUUID string, priority model.PollPriority) *PollingPoint {
+	pp := &PollingPoint{priority, ffPointUUID, ffDeviceUUID, ffNetworkUUID, ffPluginUUID, nil, 0, nil}
+	return pp
+}
+
+func (nq *NetworkPriorityPollQueue) pollQueueDebugMsg(args ...interface{}) {
+	if nstring.InEqualIgnoreCase(nq.Config.LogLevel, "DEBUG") {
+		prefix := "Modbus Poll Queue: "
+		log.Info(prefix, args)
+	}
+}
+
+func (nq *NetworkPriorityPollQueue) pollQueueErrorMsg(args ...interface{}) {
+	prefix := "Modbus Poll Queue: "
+	log.Error(prefix, args)
+}

--- a/module/shared/pollqueue/poll_queue_debug.go
+++ b/module/shared/pollqueue/poll_queue_debug.go
@@ -1,0 +1,196 @@
+package pollqueue
+
+import (
+	"fmt"
+	"github.com/NubeIO/nubeio-rubix-lib-models-go/pkg/v1/model"
+	"github.com/NubeIO/rubix-os/utils/nstring"
+	log "github.com/sirupsen/logrus"
+)
+
+func (pm *NetworkPollManager) pollQueueDebugMsg(args ...interface{}) {
+	if nstring.InEqualIgnoreCase(pm.Config.LogLevel, "DEBUG") {
+		prefix := fmt.Sprintf("%s Poll Queue: ", pm.PluginName)
+		log.Info(prefix, args)
+	}
+}
+
+func (pm *NetworkPollManager) pollQueuePollingMsg(args ...interface{}) {
+	if nstring.InEqualIgnoreCase(pm.Config.LogLevel, "POLLING") || nstring.InEqualIgnoreCase(pm.Config.LogLevel, "DEBUG") {
+		prefix := fmt.Sprintf("%s Poll Queue: ", pm.PluginName)
+		log.Info(prefix, args)
+	}
+}
+
+func (pm *NetworkPollManager) pollQueueErrorMsg(args ...interface{}) {
+	prefix := fmt.Sprintf("%s Poll Queue: ", pm.PluginName)
+	log.Error(prefix, args)
+}
+
+func (pm *NetworkPollManager) PrintPollQueuePointUUIDs() {
+	if nstring.InEqualIgnoreCase(pm.Config.LogLevel, "DEBUG") { // Added here to disable debug processes when not using logging
+		printString := "\n\n"
+		printString += fmt.Sprint("PrintPollQueuePointUUIDs: (NOTE: THE CURRENT PollPoint HAS ALREADY BEEN REMOVED FROM THE QUEUES AT THIS POINT!!\nTOTAL COUNT = ", pm.PollQueue.PriorityQueue.Len()+pm.PollQueue.StandbyPollingPoints.Len()+pm.PollQueue.OutstandingPollingPoints.Len(), "\n")
+		printString += fmt.Sprint("NextPollPoint: ")
+		if pm.PluginQueueUnloader != nil {
+			printString += fmt.Sprintf("%+v\n", pm.PluginQueueUnloader.NextPollPoint)
+		}
+		printString += fmt.Sprint("PollQueue: COUNT = ", pm.PollQueue.PriorityQueue.Len(), ": ")
+		for _, pp := range pm.PollQueue.PriorityQueue.PriorityQueue {
+			printString += fmt.Sprint(pp.FFPointUUID, " - ", pp.PollPriority, "; ")
+		}
+		printString += fmt.Sprint("", "\n")
+		printString += fmt.Sprint("StandbyPollingPoints COUNT = ", pm.PollQueue.StandbyPollingPoints.Len(), ": ")
+		for _, pp := range pm.PollQueue.StandbyPollingPoints.PriorityQueue {
+			printString += fmt.Sprint(pp.FFPointUUID, " - ", pp.PollPriority, ", repoll:", pp.RepollTimer != nil, "; ")
+		}
+		printString += fmt.Sprint("\n")
+		printString += fmt.Sprint("CurrentlyPollingPoints COUNT = ", pm.PollQueue.OutstandingPollingPoints.Len(), ": ")
+		for _, pp := range pm.PollQueue.OutstandingPollingPoints.PriorityQueue {
+			printString += fmt.Sprint(pp.FFPointUUID, " - ", pp.PollPriority, ", repoll:", pp.RepollTimer != nil, "; ")
+		}
+		printString += fmt.Sprint("\n")
+		pm.pollQueueDebugMsg(printString)
+	}
+}
+
+func (pm *NetworkPollManager) PrintPointDebugInfo(pnt *model.Point) {
+	if nstring.InEqualIgnoreCase(pm.Config.LogLevel, "DEBUG") { // Added here to disable debug processes when not using logging
+		printString := "\n\n"
+		if pnt != nil {
+			printString += fmt.Sprint("Point: ", pnt.UUID, " ", pnt.Name, "\n")
+			printString += fmt.Sprint("WriteMode: ", pnt.WriteMode, "\n")
+			if pnt.WritePollRequired != nil {
+				printString += fmt.Sprint("WritePollRequired: ", *pnt.WritePollRequired, "\n")
+			}
+			if pnt.ReadPollRequired != nil {
+				printString += fmt.Sprint("ReadPollRequired: ", *pnt.ReadPollRequired, "\n")
+			}
+			if pnt.WriteValue == nil {
+				printString += fmt.Sprint("WriteValue: nil", "\n")
+			} else {
+				printString += fmt.Sprint("WriteValue: ", *pnt.WriteValue, "\n")
+			}
+			if pnt.OriginalValue == nil {
+				printString += fmt.Sprint("OriginalValue: nil", "\n")
+			} else {
+				printString += fmt.Sprint("OriginalValue: ", *pnt.OriginalValue, "\n")
+			}
+			if pnt.PresentValue == nil {
+				printString += fmt.Sprint("PresentValue: nil", "\n")
+			} else {
+				printString += fmt.Sprint("PresentValue: ", *pnt.PresentValue, "\n")
+			}
+			if pnt.CurrentPriority == nil {
+				printString += fmt.Sprint("CurrentPriority: nil", "\n")
+			} else {
+				printString += fmt.Sprint("CurrentPriority: ", *pnt.CurrentPriority, "\n")
+			}
+			if pnt.Priority != nil {
+				if pnt.Priority.P1 != nil {
+					printString += fmt.Sprint("_1: ", *pnt.Priority.P1, "\n")
+				}
+				if pnt.Priority.P2 != nil {
+					printString += fmt.Sprint("_2: ", *pnt.Priority.P2, "\n")
+				}
+				if pnt.Priority.P3 != nil {
+					printString += fmt.Sprint("_3: ", *pnt.Priority.P3, "\n")
+				}
+				if pnt.Priority.P4 != nil {
+					printString += fmt.Sprint("_4: ", *pnt.Priority.P4, "\n")
+				}
+				if pnt.Priority.P5 != nil {
+					printString += fmt.Sprint("_5: ", *pnt.Priority.P5, "\n")
+				}
+				if pnt.Priority.P6 != nil {
+					printString += fmt.Sprint("_6: ", *pnt.Priority.P6, "\n")
+				}
+				if pnt.Priority.P7 != nil {
+					printString += fmt.Sprint("_7: ", *pnt.Priority.P7, "\n")
+				}
+				if pnt.Priority.P8 != nil {
+					printString += fmt.Sprint("_8: ", *pnt.Priority.P8, "\n")
+				}
+				if pnt.Priority.P9 != nil {
+					printString += fmt.Sprint("_9: ", *pnt.Priority.P9, "\n")
+				}
+				if pnt.Priority.P10 != nil {
+					printString += fmt.Sprint("_10: ", *pnt.Priority.P10, "\n")
+				}
+				if pnt.Priority.P11 != nil {
+					printString += fmt.Sprint("_11: ", *pnt.Priority.P11, "\n")
+				}
+				if pnt.Priority.P12 != nil {
+					printString += fmt.Sprint("_12: ", *pnt.Priority.P12, "\n")
+				}
+				if pnt.Priority.P13 != nil {
+					printString += fmt.Sprint("_13: ", *pnt.Priority.P13, "\n")
+				}
+				if pnt.Priority.P14 != nil {
+					printString += fmt.Sprint("_14: ", *pnt.Priority.P14, "\n")
+				}
+				if pnt.Priority.P15 != nil {
+					printString += fmt.Sprint("_15: ", *pnt.Priority.P15, "\n")
+				}
+				if pnt.Priority.P16 != nil {
+					printString += fmt.Sprint("_16: ", *pnt.Priority.P16, "\n")
+				}
+			}
+			pm.pollQueueDebugMsg(printString)
+			return
+		}
+		pm.pollQueueDebugMsg("ERROR: INVALID POINT")
+	}
+}
+
+func (pm *NetworkPollManager) PrintPollingPointDebugInfo(pp *PollingPoint) {
+	if pp != nil {
+		pm.pollQueueDebugMsg(fmt.Sprintf("PollingPoint pp %+v", pp))
+	}
+}
+
+func (pm *NetworkPollManager) PrintPollQueueStatistics() {
+	if nstring.InEqualIgnoreCase(pm.Config.LogLevel, "DEBUG") { // Added here to disable debug processes when not using logging
+
+		pm.PrintPollQueuePointUUIDs()
+
+		printString := "\n\n"
+		printString += fmt.Sprint("PrintPollQueueStatistics: \n")
+		printString += fmt.Sprint("MaxPollExecuteTimeSecs: ", pm.MaxPollExecuteTimeSecs, "\n")
+		printString += fmt.Sprint("AveragePollExecuteTimeSecs: ", pm.AveragePollExecuteTimeSecs, "\n")
+		printString += fmt.Sprint("MinPollExecuteTimeSecs: ", pm.MinPollExecuteTimeSecs, "\n")
+		printString += fmt.Sprint("TotalPollQueueLength: ", pm.PollQueue.PriorityQueue.Len(), "\n")
+		printString += fmt.Sprint("TotalStandbyPointsLength: ", pm.PollQueue.StandbyPollingPoints.Len(), "\n")
+		printString += fmt.Sprint("TotalPointsOutForPolling: ", pm.PollQueue.OutstandingPollingPoints.Len(), "\n")
+		printString += fmt.Sprint("ASAPPriorityPollQueueLength: ", pm.ASAPPriorityPollQueueLength, "\n")
+		printString += fmt.Sprint("HighPriorityPollQueueLength: ", pm.HighPriorityPollQueueLength, "\n")
+		printString += fmt.Sprint("NormalPriorityPollQueueLength: ", pm.NormalPriorityPollQueueLength, "\n")
+		printString += fmt.Sprint("LowPriorityPollQueueLength: ", pm.LowPriorityPollQueueLength, "\n")
+		printString += fmt.Sprint("ASAPPriorityAveragePollTime: ", pm.ASAPPriorityAveragePollTime, "\n")
+		printString += fmt.Sprint("HighPriorityAveragePollTime: ", pm.HighPriorityAveragePollTime, "\n")
+		printString += fmt.Sprint("NormalPriorityAveragePollTime: ", pm.NormalPriorityAveragePollTime, "\n")
+		printString += fmt.Sprint("LowPriorityAveragePollTime: ", pm.LowPriorityAveragePollTime, "\n")
+		printString += fmt.Sprint("TotalPollCount: ", pm.TotalPollCount, "\n")
+		printString += fmt.Sprint("ASAPPriorityPollCount: ", pm.ASAPPriorityPollCount, "\n")
+		printString += fmt.Sprint("HighPriorityPollCount: ", pm.HighPriorityPollCount, "\n")
+		printString += fmt.Sprint("NormalPriorityPollCount: ", pm.NormalPriorityPollCount, "\n")
+		printString += fmt.Sprint("LowPriorityPollCount: ", pm.LowPriorityPollCount, "\n")
+		printString += fmt.Sprint("ASAPPriorityPollCountForAvg: ", pm.ASAPPriorityPollCountForAvg, "\n")
+		printString += fmt.Sprint("HighPriorityPollCountForAvg: ", pm.HighPriorityPollCountForAvg, "\n")
+		printString += fmt.Sprint("NormalPriorityPollCountForAvg: ", pm.NormalPriorityPollCountForAvg, "\n")
+		printString += fmt.Sprint("LowPriorityPollCountForAvg: ", pm.LowPriorityPollCountForAvg, "\n")
+		printString += fmt.Sprint("ASAPPriorityMaxCycleTime: ", pm.ASAPPriorityMaxCycleTime, "\n")
+		printString += fmt.Sprint("HighPriorityMaxCycleTime: ", pm.HighPriorityMaxCycleTime, "\n")
+		printString += fmt.Sprint("NormalPriorityMaxCycleTime: ", pm.NormalPriorityMaxCycleTime, "\n")
+		printString += fmt.Sprint("LowPriorityMaxCycleTime: ", pm.LowPriorityMaxCycleTime, "\n")
+		printString += fmt.Sprint("ASAPPriorityLockupAlert: ", pm.ASAPPriorityLockupAlert, "\n")
+		printString += fmt.Sprint("HighPriorityLockupAlert: ", pm.HighPriorityLockupAlert, "\n")
+		printString += fmt.Sprint("NormalPriorityLockupAlert: ", pm.NormalPriorityLockupAlert, "\n")
+		printString += fmt.Sprint("LowPriorityLockupAlert: ", pm.LowPriorityLockupAlert, "\n")
+		printString += fmt.Sprint("PollingStartTimeUnix: ", pm.PollingStartTimeUnix, "\n")
+		printString += fmt.Sprint("BusyTime: ", pm.BusyTime, "% \n")
+		printString += fmt.Sprint("EnabledTime: ", pm.EnabledTime, " \n")
+		printString += fmt.Sprint("PortUnavailableTime: ", pm.PortUnavailableTime, " \n")
+		printString += fmt.Sprint("\n")
+		pm.pollQueueDebugMsg(printString)
+	}
+}

--- a/module/shared/pollqueue/polling_statistics.go
+++ b/module/shared/pollqueue/polling_statistics.go
@@ -1,0 +1,204 @@
+package pollqueue
+
+import (
+	"fmt"
+	"github.com/NubeIO/nubeio-rubix-lib-models-go/pkg/v1/model"
+	"math"
+	"time"
+)
+
+func (pm *NetworkPollManager) GetPollingQueueStatistics() *model.PollQueueStatistics {
+	pm.pollQueueDebugMsg("GetPollingQueueStatistics()")
+	stats := model.PollQueueStatistics{}
+	stats.Enable = pm.Enable
+	stats.MaxPollRate = pm.MaxPollRate.String()
+
+	stats.FFNetworkUUID = pm.FFNetworkUUID
+	stats.NetworkName = pm.NetworkName
+	stats.FFPluginUUID = pm.FFPluginUUID
+	stats.PluginName = pm.PluginName
+
+	MaxPollExecuteTime, _ := time.ParseDuration(fmt.Sprintf("%fs", pm.MaxPollExecuteTimeSecs))
+	stats.MaxPollExecuteTime = MaxPollExecuteTime.String()
+	AveragePollExecuteTime, _ := time.ParseDuration(fmt.Sprintf("%fs", pm.AveragePollExecuteTimeSecs))
+	stats.AveragePollExecuteTime = AveragePollExecuteTime.String()
+	MinPollExecuteTime, _ := time.ParseDuration(fmt.Sprintf("%fs", pm.MinPollExecuteTimeSecs))
+	stats.MinPollExecuteTime = MinPollExecuteTime.String()
+	stats.TotalPollQueueLength = pm.TotalPollQueueLength
+	stats.TotalStandbyPointsLength = pm.TotalStandbyPointsLength
+	stats.TotalPointsOutForPolling = pm.TotalPointsOutForPolling
+	stats.ASAPPriorityPollQueueLength = pm.ASAPPriorityPollQueueLength
+	stats.HighPriorityPollQueueLength = pm.HighPriorityPollQueueLength
+	stats.NormalPriorityPollQueueLength = pm.NormalPriorityPollQueueLength
+	stats.LowPriorityPollQueueLength = pm.LowPriorityPollQueueLength
+	ASAPPriorityAveragePollTime, _ := time.ParseDuration(fmt.Sprintf("%fs", pm.ASAPPriorityAveragePollTime))
+	stats.ASAPPriorityAveragePollTime = ASAPPriorityAveragePollTime.String()
+	HighPriorityAveragePollTime, _ := time.ParseDuration(fmt.Sprintf("%fs", pm.HighPriorityAveragePollTime))
+	stats.HighPriorityAveragePollTime = HighPriorityAveragePollTime.String()
+	NormalPriorityAveragePollTime, _ := time.ParseDuration(fmt.Sprintf("%fs", pm.NormalPriorityAveragePollTime))
+	stats.NormalPriorityAveragePollTime = NormalPriorityAveragePollTime.String()
+	LowPriorityAveragePollTime, _ := time.ParseDuration(fmt.Sprintf("%fs", pm.LowPriorityAveragePollTime))
+	stats.LowPriorityAveragePollTime = LowPriorityAveragePollTime.String()
+	stats.TotalPollCount = pm.TotalPollCount
+	stats.ASAPPriorityPollCount = pm.ASAPPriorityPollCount
+	stats.HighPriorityPollCount = pm.HighPriorityPollCount
+	stats.NormalPriorityPollCount = pm.NormalPriorityPollCount
+	stats.LowPriorityPollCount = pm.LowPriorityPollCount
+	stats.ASAPPriorityMaxCycleTime = pm.ASAPPriorityMaxCycleTime.String()
+	stats.HighPriorityMaxCycleTime = pm.HighPriorityMaxCycleTime.String()
+	stats.NormalPriorityMaxCycleTime = pm.NormalPriorityMaxCycleTime.String()
+	stats.LowPriorityMaxCycleTime = pm.LowPriorityMaxCycleTime.String()
+	stats.ASAPPriorityLockupAlert = pm.ASAPPriorityLockupAlert
+	stats.HighPriorityLockupAlert = pm.HighPriorityLockupAlert
+	stats.NormalPriorityLockupAlert = pm.NormalPriorityLockupAlert
+	stats.LowPriorityLockupAlert = pm.LowPriorityLockupAlert
+	stats.BusyTime = fmt.Sprintf("%.1f%%", pm.BusyTime)
+	EnabledTime, _ := time.ParseDuration(fmt.Sprintf("%fs", pm.EnabledTime))
+	stats.EnabledTime = EnabledTime.String()
+	PortUnavailableTime, _ := time.ParseDuration(fmt.Sprintf("%fs", pm.PortUnavailableTime))
+	stats.PortUnavailableTime = PortUnavailableTime.String()
+
+	return &stats
+}
+
+func (pm *NetworkPollManager) StartPollingStatistics() {
+	pm.pollQueueDebugMsg("StartPollingStatistics()")
+	pm.PollingStartTimeUnix = time.Now().Unix()
+	pm.AveragePollExecuteTimeSecs = 0
+	pm.MaxPollExecuteTimeSecs = 0
+	pm.MinPollExecuteTimeSecs = 0
+	pm.ASAPPriorityAveragePollTime = 0
+	pm.HighPriorityAveragePollTime = 0
+	pm.NormalPriorityAveragePollTime = 0
+	pm.LowPriorityAveragePollTime = 0
+	pm.TotalPollCount = 0
+	pm.ASAPPriorityPollCount = 0
+	pm.HighPriorityPollCount = 0
+	pm.NormalPriorityPollCount = 0
+	pm.LowPriorityPollCount = 0
+	pm.ASAPPriorityPollCountForAvg = 0
+	pm.HighPriorityPollCountForAvg = 0
+	pm.NormalPriorityPollCountForAvg = 0
+	pm.LowPriorityPollCountForAvg = 0
+	pm.ASAPPriorityLockupAlert = false
+	pm.HighPriorityLockupAlert = false
+	pm.NormalPriorityLockupAlert = false
+	pm.LowPriorityLockupAlert = false
+	pm.PortUnavailableTime = 0
+	pm.PortUnavailableStartTime = 0
+}
+
+func (pm *NetworkPollManager) PollCompleteStatsUpdate(pp *PollingPoint, pollTimeSecs float64) {
+	pm.pollQueueDebugMsg("PollCompleteStatsUpdate()")
+
+	if pm.MaxPollExecuteTimeSecs == 0 || pollTimeSecs > pm.MaxPollExecuteTimeSecs {
+		pm.MaxPollExecuteTimeSecs = pollTimeSecs
+	}
+	if pm.MinPollExecuteTimeSecs == 0 || pollTimeSecs < pm.MinPollExecuteTimeSecs {
+		pm.MinPollExecuteTimeSecs = pollTimeSecs
+	}
+	pm.AveragePollExecuteTimeSecs = ((pm.AveragePollExecuteTimeSecs * float64(pm.TotalPollCount)) + pollTimeSecs) / (float64(pm.TotalPollCount) + 1)
+	pm.TotalPollCount++
+	pm.EnabledTime = time.Since(time.Unix(pm.PollingStartTimeUnix, 0)).Seconds()
+	pm.BusyTime = math.Round((((pm.AveragePollExecuteTimeSecs*float64(pm.TotalPollCount))/pm.EnabledTime)*100)*1000) / 1000 // percentage rounded to 3 decimal places
+
+	pm.TotalPollQueueLength = int64(pm.PollQueue.PriorityQueue.Len())
+	pm.TotalStandbyPointsLength = int64(pm.PollQueue.StandbyPollingPoints.Len())
+	pm.TotalPointsOutForPolling = int64(pm.PollQueue.OutstandingPollingPoints.Len())
+
+	pm.ASAPPriorityPollQueueLength = 0
+	pm.HighPriorityPollQueueLength = 0
+	pm.NormalPriorityPollQueueLength = 0
+	pm.LowPriorityPollQueueLength = 0
+
+	for _, pp := range pm.PollQueue.PriorityQueue.PriorityQueue {
+		if pp != nil {
+			switch pp.PollPriority {
+			case model.PRIORITY_ASAP:
+				pm.ASAPPriorityPollQueueLength++
+			case model.PRIORITY_HIGH:
+				pm.HighPriorityPollQueueLength++
+			case model.PRIORITY_NORMAL:
+				pm.NormalPriorityPollQueueLength++
+			case model.PRIORITY_LOW:
+				pm.LowPriorityPollQueueLength++
+			}
+		}
+	}
+	pm.TotalPollQueueLength = int64(pm.PollQueue.PriorityQueue.Len())
+
+	switch pp.PollPriority {
+	case model.PRIORITY_ASAP:
+		pm.ASAPPriorityPollCount++
+		if pp.QueueEntryTime <= 0 {
+			return
+		}
+		pollTime := float64(time.Now().Unix() - pp.QueueEntryTime)
+		pm.ASAPPriorityAveragePollTime = ((pm.ASAPPriorityAveragePollTime * float64(pm.ASAPPriorityPollCountForAvg)) + pollTime) / (float64(pm.ASAPPriorityPollCountForAvg) + 1)
+		pm.ASAPPriorityPollCountForAvg++
+
+	case model.PRIORITY_HIGH:
+		pm.HighPriorityPollCount++
+		if pp.QueueEntryTime <= 0 {
+			return
+		}
+		pollTime := float64(time.Now().Unix() - pp.QueueEntryTime)
+		pm.HighPriorityAveragePollTime = ((pm.HighPriorityAveragePollTime * float64(pm.HighPriorityPollCountForAvg)) + pollTime) / (float64(pm.HighPriorityPollCountForAvg) + 1)
+		pm.HighPriorityPollCountForAvg++
+
+	case model.PRIORITY_NORMAL:
+		pm.NormalPriorityPollCount++
+		if pp.QueueEntryTime <= 0 {
+			return
+		}
+		pollTime := float64(time.Now().Unix() - pp.QueueEntryTime)
+		pm.NormalPriorityAveragePollTime = ((pm.NormalPriorityAveragePollTime * float64(pm.NormalPriorityPollCountForAvg)) + pollTime) / (float64(pm.NormalPriorityPollCountForAvg) + 1)
+		pm.NormalPriorityPollCountForAvg++
+
+	case model.PRIORITY_LOW:
+		pm.LowPriorityPollCount++
+		if pp.QueueEntryTime <= 0 {
+			return
+		}
+		pollTime := float64(time.Now().Unix() - pp.QueueEntryTime)
+		pm.LowPriorityAveragePollTime = ((pm.LowPriorityAveragePollTime * float64(pm.LowPriorityPollCountForAvg)) + pollTime) / (float64(pm.LowPriorityPollCountForAvg) + 1)
+		pm.LowPriorityPollCountForAvg++
+
+	}
+
+}
+
+func (pm *NetworkPollManager) PartialPollStatsUpdate() {
+	pm.pollQueueDebugMsg("PartialPollStatsUpdate()")
+	pm.TotalPollQueueLength = int64(pm.PollQueue.PriorityQueue.Len())
+	pm.TotalStandbyPointsLength = int64(pm.PollQueue.StandbyPollingPoints.Len())
+	pm.TotalPointsOutForPolling = int64(pm.PollQueue.OutstandingPollingPoints.Len())
+
+	pm.EnabledTime = time.Since(time.Unix(pm.PollingStartTimeUnix, 0)).Seconds()
+
+	if pm.PortUnavailableTimeout != nil {
+		pm.PortUnavailableTime += time.Since(time.Unix(pm.PortUnavailableStartTime, 0)).Seconds()
+		pm.PortUnavailableStartTime = time.Now().Unix()
+	}
+
+	pm.ASAPPriorityPollQueueLength = 0
+	pm.HighPriorityPollQueueLength = 0
+	pm.NormalPriorityPollQueueLength = 0
+	pm.LowPriorityPollQueueLength = 0
+
+	for _, pp := range pm.PollQueue.PriorityQueue.PriorityQueue {
+		if pp != nil {
+			switch pp.PollPriority {
+			case model.PRIORITY_ASAP:
+				pm.ASAPPriorityPollQueueLength++
+			case model.PRIORITY_HIGH:
+				pm.HighPriorityPollQueueLength++
+			case model.PRIORITY_NORMAL:
+				pm.NormalPriorityPollQueueLength++
+			case model.PRIORITY_LOW:
+				pm.LowPriorityPollQueueLength++
+			}
+		}
+	}
+	pm.TotalPollQueueLength = int64(pm.PollQueue.PriorityQueue.Len())
+}

--- a/module/shared/pollqueue/queue_loader.go
+++ b/module/shared/pollqueue/queue_loader.go
@@ -1,0 +1,595 @@
+package pollqueue
+
+import (
+	"container/heap"
+	"errors"
+	"fmt"
+	"github.com/NubeIO/nubeio-rubix-lib-helpers-go/pkg/times/utilstime"
+	"github.com/NubeIO/nubeio-rubix-lib-models-go/pkg/v1/model"
+	"github.com/NubeIO/rubix-os/utils/boolean"
+	"time"
+)
+
+// REFS:
+//  - GOLANG HEAP https://pkg.go.dev/container/heap
+//  - Worker Queue tutorial: https://www.opsdash.com/blog/job-queues-in-go.html
+
+func (pm *NetworkPollManager) RebuildPollingQueue() error {
+	// TODO: STOP ANY OTHER QUEUE LOADERS
+	pm.pollQueueDebugMsg("RebuildPollingQueue()")
+	wasRunning := pm.PluginQueueUnloader != nil
+	pm.EmptyQueue()
+	// var arg api.Args
+	// arg.WithDevices = true
+	// arg.WithPoints = true
+	net, err := pm.Marshaller.GetNetwork(pm.FFNetworkUUID, "with_devices=true&&with_points=true")
+	if err != nil || net.Devices == nil || len(net.Devices) == 0 {
+		pm.pollQueueDebugMsg("RebuildPollingQueue() couldn't find any devices for the network %s", pm.FFNetworkUUID)
+		return errors.New(fmt.Sprintf("NetworkPollManager.RebuildPollingQueue: couldn't find any devices for the network %s", pm.FFNetworkUUID))
+	}
+	devs := net.Devices
+	for _, dev := range devs { // DEVICES
+		if dev.NetworkUUID == pm.FFNetworkUUID && boolean.IsTrue(dev.Enable) {
+			for _, pnt := range dev.Points { // POINTS
+				if pnt.DeviceUUID == dev.UUID && boolean.IsTrue(pnt.Enable) {
+					pp := NewPollingPoint(pnt.UUID, pnt.DeviceUUID, dev.NetworkUUID, pm.FFPluginUUID)
+					pp.PollPriority = pnt.PollPriority
+					pm.pollQueueDebugMsg(fmt.Sprintf("RebuildPollingQueue() pp: %+v", pp))
+					pp.LockupAlertTimer = pm.MakeLockupTimerFunc(pp.PollPriority) // starts a countdown for queue lockup alerts.
+					pm.PollQueue.AddPollingPoint(pp)
+				} else {
+					pm.pollQueueDebugMsg(fmt.Sprintf("NetworkPollManager.RebuildPollingQueue: Point (%s) is not enabled", pnt.UUID))
+				}
+			}
+		} else {
+			pm.pollQueueDebugMsg(fmt.Sprintf("NetworkPollManager.RebuildPollingQueue: Device (%s) is not enabled", dev.UUID))
+		}
+	}
+	heap.Init(pm.PollQueue.PriorityQueue)
+	if wasRunning {
+		pm.StartQueueUnloader()
+	}
+	// TODO: START ANY OTHER REQUIRED QUEUE LOADERS/OPTIMIZERS
+	// pm.PrintPollQueuePointUUIDs()
+	return nil
+}
+
+func (pm *NetworkPollManager) PollingPointCompleteNotification(pp *PollingPoint, writeSuccess, readSuccess bool, pollTimeSecs float64, pointUpdate, resetToConfiguredPriority bool, retryType PollRetryType, actualPoll, pollingWasNotRequired, justToReAdd bool) {
+	if !justToReAdd {
+		pm.pollQueuePollingMsg(fmt.Sprintf("POLLING COMPLETE: Point UUID: %s, writeSuccess: %t, readSuccess: %t, pointUpdate: %t, actualPoll: %t, pollingWasNotRequired: %t, justToReAdd: %t, retryType: %s, pollTime: %f", pp.FFPointUUID, writeSuccess, readSuccess, pointUpdate, actualPoll, pollingWasNotRequired, justToReAdd, retryType, pollTimeSecs))
+	}
+
+	if !actualPoll && !justToReAdd { // This posts the next polling point immediately (faster than the MaxPollRate) because no poll was actually made.
+		pm.postNextPointCallback()
+	}
+
+	if !justToReAdd {
+		_, success := pm.PollQueue.OutstandingPollingPoints.RemovePollingPointByPointUUID(pp.FFPointUUID)
+		if !success {
+			// It's ok to get this error message when adding/re-adding points.
+			pm.pollQueueErrorMsg("NetworkPollManager.PollingPointCompleteNotification(): couldn't find polling point in OutstandingPollingPoints, %s", pp.FFPointUUID)
+		}
+	}
+
+	if !pointUpdate {
+		pm.PollCompleteStatsUpdate(pp, pollTimeSecs) // This will update the relevant PollManager statistics.
+	}
+
+	point, err := pm.Marshaller.GetPoint(pp.FFPointUUID, "with_priority=true") // api.Args{WithPriority: true}
+	if point == nil || err != nil {
+		pm.pollQueueErrorMsg("NetworkPollManager.PollingPointCompleteNotification(): couldn't find point %s", pp.FFPointUUID)
+		return
+	}
+	// TODO: potentially only required on writeSuccess (but possibility of lockup on a bad point)
+	// Reset poll priority to set value (in cases where pp has been escalated to ASAP).
+	if resetToConfiguredPriority {
+		pp.PollPriority = point.PollPriority
+	}
+
+	val, ok := pm.PollQueue.PointsUpdatedWhilePolling[point.UUID]
+	if ok {
+		delete(pm.PollQueue.PointsUpdatedWhilePolling, point.UUID)
+		if val == true { // point needs an ASAP write
+			pp.PollPriority = model.PRIORITY_ASAP
+			pp.LockupAlertTimer = pm.MakeLockupTimerFunc(pp.PollPriority) // starts a countdown for queue lockup alerts.
+			pm.PollQueue.AddPollingPoint(pp)                              // re-add to poll queue immediately
+			return
+		}
+	}
+
+	// pm.pollQueuePollingMsg(fmt.Sprintf("PollingPointCompleteNotification: point %+v", point))
+	// pm.PrintPointDebugInfo(point)
+
+	// If the device was deleted while this point was being polled, discard the PollingPoint
+	if !pointUpdate && !pm.PollQueue.CheckIfActiveDevicesListIncludes(point.DeviceUUID) {
+		return
+	}
+
+	switch point.WriteMode {
+	case model.ReadOnce: // ReadOnce          If read_successful then don't re-add.
+		point.WritePollRequired = boolean.NewFalse()
+		if retryType == NEVER_RETRY || ((readSuccess || pollingWasNotRequired) && retryType == NORMAL_RETRY) {
+			point.ReadPollRequired = boolean.NewFalse()
+			if pp.RepollTimer != nil {
+				pp.RepollTimer.Stop()
+				pp.RepollTimer = nil
+			}
+			addSuccess := pm.PollQueue.StandbyPollingPoints.AddPollingPoint(pp)
+			if !addSuccess {
+				pm.pollQueueErrorMsg(fmt.Sprintf("Modbus PollingPointCompleteNotification(): polling point could not be added to StandbyPollingPoints slice.  (%s)", pp.FFPointUUID))
+			}
+		} else if (boolean.IsTrue(point.ReadPollRequired) && !readSuccess && retryType == NORMAL_RETRY) || retryType == IMMEDIATE_RETRY {
+			point.ReadPollRequired = boolean.NewTrue()
+			if pp.RepollTimer != nil {
+				pp.RepollTimer.Stop()
+				pp.RepollTimer = nil
+			}
+			pp.LockupAlertTimer = pm.MakeLockupTimerFunc(pp.PollPriority) // starts a countdown for queue lockup alerts.
+			pm.PollQueue.AddPollingPoint(pp)
+		} else if retryType == DELAYED_RETRY {
+			point.ReadPollRequired = boolean.NewTrue()
+			duration := pm.GetPollRateDuration(point.PollRate, pp.FFDeviceUUID)
+			// This line sets a timer to re-add the point to the poll queue after the PollRate time.
+			pp.RepollTimer = time.AfterFunc(duration, pm.MakePollingPointRepollCallback(pp, point.WriteMode))
+			addSuccess := pm.PollQueue.StandbyPollingPoints.AddPollingPoint(pp)
+			if !addSuccess {
+				pm.pollQueueErrorMsg(fmt.Sprintf("Modbus PollingPointCompleteNotification(): polling point could not be added to StandbyPollingPoints slice.  (%s)", pp.FFPointUUID))
+			}
+		}
+
+	case model.ReadOnly: // ReadOnly          Re-add with ReadPollRequired true, WritePollRequired false.
+		point.WritePollRequired = boolean.NewFalse()
+		point.ReadPollRequired = boolean.NewTrue()
+		if ((readSuccess || pollingWasNotRequired) && retryType == NORMAL_RETRY) || retryType == DELAYED_RETRY {
+			duration := pm.GetPollRateDuration(point.PollRate, pp.FFDeviceUUID)
+			// This line sets a timer to re-add the point to the poll queue after the PollRate time.
+			pp.RepollTimer = time.AfterFunc(duration, pm.MakePollingPointRepollCallback(pp, point.WriteMode))
+			addSuccess := pm.PollQueue.StandbyPollingPoints.AddPollingPoint(pp)
+			if !addSuccess {
+				pm.pollQueueErrorMsg(fmt.Sprintf("Modbus PollingPointCompleteNotification(): polling point could not be added to StandbyPollingPoints slice.  (%s)", pp.FFPointUUID))
+			}
+		} else if (!readSuccess && retryType == NORMAL_RETRY) || retryType == IMMEDIATE_RETRY {
+			if pp.RepollTimer != nil {
+				pp.RepollTimer.Stop()
+				pp.RepollTimer = nil
+			}
+			pp.LockupAlertTimer = pm.MakeLockupTimerFunc(pp.PollPriority) // starts a countdown for queue lockup alerts.  TODO: This might conflict with pausing polling on PortUnavailable
+			pm.PollQueue.AddPollingPoint(pp)                              // re-add to poll queue immediately
+		} else if retryType == NEVER_RETRY {
+			if pp.RepollTimer != nil {
+				pp.RepollTimer.Stop()
+				pp.RepollTimer = nil
+			}
+			addSuccess := pm.PollQueue.StandbyPollingPoints.AddPollingPoint(pp)
+			if !addSuccess {
+				pm.pollQueueErrorMsg(fmt.Sprintf("Modbus PollingPointCompleteNotification(): polling point could not be added to StandbyPollingPoints slice.  (%s)", pp.FFPointUUID))
+			}
+		}
+
+	case model.WriteOnce: // WriteOnce         If write_successful then don't re-add.
+		point.ReadPollRequired = boolean.NewFalse()
+		if ((writeSuccess || pollingWasNotRequired) && retryType == NORMAL_RETRY) || retryType == NEVER_RETRY {
+			point.WritePollRequired = boolean.NewFalse()
+			if pp.RepollTimer != nil {
+				pp.RepollTimer.Stop()
+				pp.RepollTimer = nil
+			}
+			addSuccess := pm.PollQueue.StandbyPollingPoints.AddPollingPoint(pp)
+			if !addSuccess {
+				pm.pollQueueErrorMsg(fmt.Sprintf("Modbus PollingPointCompleteNotification(): polling point could not be added to StandbyPollingPoints slice.  (%s)", pp.FFPointUUID))
+			}
+		} else if (boolean.IsTrue(point.WritePollRequired) && !writeSuccess && retryType == NORMAL_RETRY) || retryType == IMMEDIATE_RETRY {
+			point.WritePollRequired = boolean.NewTrue() // TODO: this might cause these points to write more than once.
+			if pp.RepollTimer != nil {
+				pp.RepollTimer.Stop()
+				pp.RepollTimer = nil
+			}
+			pp.LockupAlertTimer = pm.MakeLockupTimerFunc(pp.PollPriority) // starts a countdown for queue lockup alerts.
+			pm.PollQueue.AddPollingPoint(pp)                              // re-add to poll queue immediately
+		} else if retryType == DELAYED_RETRY {
+			point.WritePollRequired = boolean.NewTrue()
+			duration := pm.GetPollRateDuration(point.PollRate, pp.FFDeviceUUID)
+			// This line sets a timer to re-add the point to the poll queue after the PollRate time.
+			pp.RepollTimer = time.AfterFunc(duration, pm.MakePollingPointRepollCallback(pp, point.WriteMode))
+			addSuccess := pm.PollQueue.StandbyPollingPoints.AddPollingPoint(pp)
+			if !addSuccess {
+				pm.pollQueueErrorMsg(fmt.Sprintf("Modbus PollingPointCompleteNotification(): polling point could not be added to StandbyPollingPoints slice.  (%s)", pp.FFPointUUID))
+			}
+		}
+
+	case model.WriteOnceReadOnce: // WriteOnceReadOnce     If write_successful and read_success then don't re-add.
+		if (boolean.IsTrue(point.WritePollRequired) && writeSuccess && retryType == NORMAL_RETRY) || retryType == NEVER_RETRY {
+			point.WritePollRequired = boolean.NewFalse()
+			if pp.RepollTimer != nil {
+				pp.RepollTimer.Stop()
+				pp.RepollTimer = nil
+			}
+			addSuccess := pm.PollQueue.StandbyPollingPoints.AddPollingPoint(pp)
+			if !addSuccess {
+				pm.pollQueueErrorMsg(fmt.Sprintf("Modbus PollingPointCompleteNotification(): polling point could not be added to StandbyPollingPoints slice.  (%s)", pp.FFPointUUID))
+			}
+		} else if pointUpdate || (boolean.IsTrue(point.WritePollRequired) && !writeSuccess && retryType == NORMAL_RETRY) || retryType == IMMEDIATE_RETRY {
+			point.WritePollRequired = boolean.NewTrue()
+			if pointUpdate {
+				point.ReadPollRequired = boolean.NewTrue()
+			}
+			if pp.RepollTimer != nil {
+				pp.RepollTimer.Stop()
+				pp.RepollTimer = nil
+			}
+			pp.LockupAlertTimer = pm.MakeLockupTimerFunc(pp.PollPriority) // starts a countdown for queue lockup alerts.
+			pm.PollQueue.AddPollingPoint(pp)                              // re-add to poll queue immediately
+			break
+		} else if retryType == DELAYED_RETRY {
+			point.WritePollRequired = boolean.NewTrue()
+			point.ReadPollRequired = boolean.NewTrue()
+			duration := pm.GetPollRateDuration(point.PollRate, pp.FFDeviceUUID)
+			// This line sets a timer to re-add the point to the poll queue after the PollRate time.
+			pp.RepollTimer = time.AfterFunc(duration, pm.MakePollingPointRepollCallback(pp, point.WriteMode))
+			addSuccess := pm.PollQueue.StandbyPollingPoints.AddPollingPoint(pp)
+			if !addSuccess {
+				pm.pollQueueErrorMsg(fmt.Sprintf("Modbus PollingPointCompleteNotification(): polling point could not be added to StandbyPollingPoints slice.  (%s)", pp.FFPointUUID))
+			}
+			break
+		}
+		if readSuccess && retryType == NORMAL_RETRY || retryType == NEVER_RETRY {
+			point.ReadPollRequired = boolean.NewFalse()
+			if pp.RepollTimer != nil {
+				pp.RepollTimer.Stop()
+				pp.RepollTimer = nil
+			}
+			addSuccess := pm.PollQueue.StandbyPollingPoints.AddPollingPoint(pp)
+			if !addSuccess {
+				pm.pollQueueErrorMsg(fmt.Sprintf("Modbus PollingPointCompleteNotification(): polling point could not be added to StandbyPollingPoints slice.  (%s)", pp.FFPointUUID))
+			}
+		} else if boolean.IsTrue(point.ReadPollRequired) && !readSuccess && retryType == NORMAL_RETRY || retryType == IMMEDIATE_RETRY {
+			point.ReadPollRequired = boolean.NewTrue()
+			if pp.RepollTimer != nil {
+				pp.RepollTimer.Stop()
+				pp.RepollTimer = nil
+			}
+			pp.LockupAlertTimer = pm.MakeLockupTimerFunc(pp.PollPriority) // starts a countdown for queue lockup alerts.
+			pm.PollQueue.AddPollingPoint(pp)                              // re-add to poll queue immediately
+		}
+
+	case model.WriteAlways: // WriteAlways       Re-add with ReadPollRequired false, WritePollRequired true. confirm that a successful write ensures the value is set to the write value.
+		point.ReadPollRequired = boolean.NewFalse()
+		point.WritePollRequired = boolean.NewTrue()
+		if (writeSuccess && retryType == NORMAL_RETRY) || retryType == DELAYED_RETRY {
+			duration := pm.GetPollRateDuration(point.PollRate, pp.FFDeviceUUID)
+			// This line sets a timer to re-add the point to the poll queue after the PollRate time.
+			pp.RepollTimer = time.AfterFunc(duration, pm.MakePollingPointRepollCallback(pp, point.WriteMode))
+			addSuccess := pm.PollQueue.StandbyPollingPoints.AddPollingPoint(pp)
+			if !addSuccess {
+				pm.pollQueueErrorMsg(fmt.Sprintf("Modbus PollingPointCompleteNotification(): polling point could not be added to StandbyPollingPoints slice.  (%s)", pp.FFPointUUID))
+			}
+			break
+		} else if (!writeSuccess && retryType == NORMAL_RETRY) || retryType == IMMEDIATE_RETRY {
+			if pp.RepollTimer != nil {
+				pp.RepollTimer.Stop()
+				pp.RepollTimer = nil
+			}
+			pp.LockupAlertTimer = pm.MakeLockupTimerFunc(pp.PollPriority) // starts a countdown for queue lockup alerts.
+			pm.PollQueue.AddPollingPoint(pp)                              // re-add to poll queue immediately
+			break
+		} else if retryType == NEVER_RETRY {
+			if pp.RepollTimer != nil {
+				pp.RepollTimer.Stop()
+				pp.RepollTimer = nil
+			}
+			addSuccess := pm.PollQueue.StandbyPollingPoints.AddPollingPoint(pp)
+			if !addSuccess {
+				pm.pollQueueErrorMsg(fmt.Sprintf("Modbus PollingPointCompleteNotification(): polling point could not be added to StandbyPollingPoints slice.  (%s)", pp.FFPointUUID))
+			}
+		}
+
+	case model.WriteOnceThenRead: // WriteOnceThenRead     If write_successful: Re-add with ReadPollRequired true, WritePollRequired false.
+		point.ReadPollRequired = boolean.NewTrue()
+		if retryType == NEVER_RETRY {
+			if writeSuccess {
+				point.WritePollRequired = boolean.NewFalse()
+			}
+			if pp.RepollTimer != nil {
+				pp.RepollTimer.Stop()
+				pp.RepollTimer = nil
+			}
+			addSuccess := pm.PollQueue.StandbyPollingPoints.AddPollingPoint(pp)
+			if !addSuccess {
+				pm.pollQueueErrorMsg(fmt.Sprintf("Modbus PollingPointCompleteNotification(): polling point could not be added to StandbyPollingPoints slice.  (%s)", pp.FFPointUUID))
+			}
+		} else if pointUpdate || (boolean.IsTrue(point.WritePollRequired) && !writeSuccess && retryType == NORMAL_RETRY) || retryType == IMMEDIATE_RETRY {
+			if writeSuccess {
+				point.WritePollRequired = boolean.NewFalse()
+			}
+			if pp.RepollTimer != nil {
+				pp.RepollTimer.Stop()
+				pp.RepollTimer = nil
+			}
+			pp.LockupAlertTimer = pm.MakeLockupTimerFunc(pp.PollPriority) // starts a countdown for queue lockup alerts.
+			pm.PollQueue.AddPollingPoint(pp)                              // re-add to poll queue immediately
+			break
+		} else if (boolean.IsTrue(point.WritePollRequired) && writeSuccess && retryType == NORMAL_RETRY) || retryType == DELAYED_RETRY {
+			if writeSuccess {
+				point.WritePollRequired = boolean.NewFalse()
+			}
+			duration := pm.GetPollRateDuration(point.PollRate, pp.FFDeviceUUID)
+			// This line sets a timer to re-add the point to the poll queue after the PollRate time.
+			pp.RepollTimer = time.AfterFunc(duration, pm.MakePollingPointRepollCallback(pp, point.WriteMode))
+			addSuccess := pm.PollQueue.StandbyPollingPoints.AddPollingPoint(pp)
+			if !addSuccess {
+				pm.pollQueueErrorMsg(fmt.Sprintf("Modbus PollingPointCompleteNotification(): polling point could not be added to StandbyPollingPoints slice.  (%s)", pp.FFPointUUID))
+			}
+			break
+		}
+		if readSuccess && retryType == NORMAL_RETRY || retryType == DELAYED_RETRY {
+			duration := pm.GetPollRateDuration(point.PollRate, pp.FFDeviceUUID)
+			// This line sets a timer to re-add the point to the poll queue after the PollRate time.
+			pp.RepollTimer = time.AfterFunc(duration, pm.MakePollingPointRepollCallback(pp, point.WriteMode))
+			addSuccess := pm.PollQueue.StandbyPollingPoints.AddPollingPoint(pp)
+			if !addSuccess {
+				pm.pollQueueErrorMsg(fmt.Sprintf("Modbus PollingPointCompleteNotification(): polling point could not be added to StandbyPollingPoints slice.  (%s)", pp.FFPointUUID))
+			}
+			break
+		} else if !readSuccess && retryType == NORMAL_RETRY || retryType == IMMEDIATE_RETRY {
+			if pp.RepollTimer != nil {
+				pp.RepollTimer.Stop()
+				pp.RepollTimer = nil
+			}
+			pp.LockupAlertTimer = pm.MakeLockupTimerFunc(pp.PollPriority) // starts a countdown for queue lockup alerts.
+			pm.PollQueue.AddPollingPoint(pp)                              // re-add to poll queue immediately
+		}
+
+	case model.WriteAndMaintain: // WriteAndMaintain    If write_successful: Re-add with ReadPollRequired true, WritePollRequired false.  Need to check that write value matches present value after each read poll.
+		point.ReadPollRequired = boolean.NewTrue()
+		// pm.pollQueueDebugMsg(fmt.Sprintf("WriteAndMaintain point %+v\n", point))
+		if (boolean.IsTrue(point.WritePollRequired) && !writeSuccess && retryType == NORMAL_RETRY) || retryType == IMMEDIATE_RETRY {
+			if pp.RepollTimer != nil {
+				pp.RepollTimer.Stop()
+				pp.RepollTimer = nil
+			}
+			// point.WritePollRequired = boolean.NewTrue()
+			pp.LockupAlertTimer = pm.MakeLockupTimerFunc(pp.PollPriority) // starts a countdown for queue lockup alerts.
+			pm.PollQueue.AddPollingPoint(pp)
+			break
+		} else if retryType == DELAYED_RETRY {
+			duration := pm.GetPollRateDuration(point.PollRate, pp.FFDeviceUUID)
+			// This line sets a timer to re-add the point to the poll queue after the PollRate time.
+			pp.RepollTimer = time.AfterFunc(duration, pm.MakePollingPointRepollCallback(pp, point.WriteMode))
+			addSuccess := pm.PollQueue.StandbyPollingPoints.AddPollingPoint(pp)
+			if !addSuccess {
+				pm.pollQueueErrorMsg(fmt.Sprintf("Modbus PollingPointCompleteNotification(): polling point could not be added to StandbyPollingPoints slice.  (%s)", pp.FFPointUUID))
+			}
+			break
+		} else if retryType == NEVER_RETRY {
+			if pp.RepollTimer != nil {
+				pp.RepollTimer.Stop()
+				pp.RepollTimer = nil
+			}
+			addSuccess := pm.PollQueue.StandbyPollingPoints.AddPollingPoint(pp)
+			if !addSuccess {
+				pm.pollQueueErrorMsg(fmt.Sprintf("Modbus PollingPointCompleteNotification(): polling point could not be added to StandbyPollingPoints slice.  (%s)", pp.FFPointUUID))
+			}
+			break
+		}
+
+		if point.WriteValue != nil {
+			noPV := true
+			var readValue float64
+			if point.OriginalValue != nil {
+				noPV = false
+				readValue = *point.OriginalValue
+			}
+			if noPV || readValue != *point.WriteValue {
+				if pp.RepollTimer != nil {
+					pp.RepollTimer.Stop()
+					pp.RepollTimer = nil
+				}
+				point.WritePollRequired = boolean.NewTrue()
+				pp.LockupAlertTimer = pm.MakeLockupTimerFunc(pp.PollPriority) // starts a countdown for queue lockup alerts.
+				pm.PollQueue.AddPollingPoint(pp)                              // re-add to poll queue immediately
+			} else {
+				point.WritePollRequired = boolean.NewFalse()
+				duration := pm.GetPollRateDuration(point.PollRate, pp.FFDeviceUUID)
+				// This line sets a timer to re-add the point to the poll queue after the PollRate time.
+				pp.RepollTimer = time.AfterFunc(duration, pm.MakePollingPointRepollCallback(pp, point.WriteMode))
+				addSuccess := pm.PollQueue.StandbyPollingPoints.AddPollingPoint(pp)
+				if !addSuccess {
+					pm.pollQueueErrorMsg(fmt.Sprintf("Modbus PollingPointCompleteNotification(): polling point could not be added to StandbyPollingPoints slice.  (%s)", pp.FFPointUUID))
+				}
+			}
+		} else {
+			// If WriteValue is nil we still need to re-add the point to perform a read
+			point.WritePollRequired = boolean.NewFalse()
+			duration := pm.GetPollRateDuration(point.PollRate, pp.FFDeviceUUID)
+			// This line sets a timer to re-add the point to the poll queue after the PollRate time.
+			pp.RepollTimer = time.AfterFunc(duration, pm.MakePollingPointRepollCallback(pp, point.WriteMode))
+			addSuccess := pm.PollQueue.StandbyPollingPoints.AddPollingPoint(pp)
+			if !addSuccess {
+				pm.pollQueueErrorMsg(fmt.Sprintf("Modbus PollingPointCompleteNotification(): polling point could not be added to StandbyPollingPoints slice.  (%s)", pp.FFPointUUID))
+			}
+		}
+	}
+
+	// pm.pollQueueDebugMsg(fmt.Sprintf("PollingPointCompleteNotification (ABOUT TO DB UPDATE): point  %+v", point))
+	// point.PrintPointValues()
+	// TODO: WOULD BE GOOD IF THIS COULD BE MOVED TO app.go
+	resetFaults := readSuccess || writeSuccess
+	if resetFaults {
+		point.CommonFault.InFault = false
+		point.CommonFault.MessageLevel = model.MessageLevel.Info
+		point.CommonFault.MessageCode = model.CommonFaultCode.PointWriteOk
+		point.CommonFault.Message = fmt.Sprintf("last-updated: %s", utilstime.TimeStamp())
+		point.CommonFault.LastOk = time.Now().UTC()
+	}
+	point, err = pm.Marshaller.UpdatePoint(point.UUID, point)
+	// printPointDebugInfo(point)
+	pm.pollQueuePollingMsg("^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^")
+}
+
+func (pm *NetworkPollManager) MakePollingPointRepollCallback(pp *PollingPoint, writeMode model.WriteMode) func() {
+	// log.Info("MakePollingPointRepollCallback()")
+	f := func() {
+		// pm.pollQueueDebugMsg(fmt.Sprintf("CALL PollingPointRepollCallback func() pp: %+v", pp))
+		pp.RepollTimer = nil
+		_, removeSuccess := pm.PollQueue.StandbyPollingPoints.RemovePollingPointByPointUUID(pp.FFPointUUID)
+		if !removeSuccess {
+			pm.pollQueueErrorMsg(fmt.Sprintf("Modbus MakePollingPointRepollCallback(): polling point could not be found in StandbyPollingPoints.  (%s)", pp.FFPointUUID))
+		}
+		/*
+			point, err := pm.marshaller.GetPoint(pp.FFPointUUID, api.Args{WithPriority: true})
+			if point == nil || err != nil {
+				pm.pollQueueDebugMsg(fmt.Sprintf("NetworkPollManager.PollingPointCompleteNotification(): couldn't find point %s", pp.FFPointUUID))
+				return
+			}
+
+				pointUpdateReq := false
+
+				switch writeMode {
+				case model.ReadOnce:
+
+				case model.ReadOnly: // ReadOnly          Re-add with ReadPollRequired true, WritePollRequired false.
+					point.ReadPollRequired = boolean.NewTrue()
+					point.WritePollRequired = boolean.NewFalse()
+					pointUpdateReq = true
+
+				case model.WriteOnce: // WriteOnce         If write_successful then don't re-add.
+
+				case model.WriteOnceReadOnce: // WriteOnceReadOnce     If write_successful and read_success then don't re-add.
+
+				case model.WriteAlways: // WriteAlways       Re-add with ReadPollRequired false, WritePollRequired true. confirm that a successful write ensures the value is set to the write value.
+					point.ReadPollRequired = boolean.NewFalse()
+					point.WritePollRequired = boolean.NewTrue()
+					pointUpdateReq = true
+
+				case model.WriteOnceThenRead: // WriteOnceThenRead     If write_successful: Re-add with ReadPollRequired true, WritePollRequired false.
+					point.ReadPollRequired = boolean.NewTrue()
+					point.WritePollRequired = boolean.NewFalse()
+					pointUpdateReq = true
+
+				case model.WriteAndMaintain: // WriteAndMaintain    If write_successful: Re-add with ReadPollRequired true, WritePollRequired false.  Need to check that write value matches present value after each read poll.
+					point.ReadPollRequired = boolean.NewTrue()
+					point.WritePollRequired = boolean.NewFalse()
+					pointUpdateReq = true
+				}
+		*/
+
+		// Now add the polling point back to the polling queue
+		pp.LockupAlertTimer = pm.MakeLockupTimerFunc(pp.PollPriority) // starts a countdown for queue lockup alerts.
+		pm.PollQueue.AddPollingPoint(pp)
+
+		/*
+			if pointUpdateReq {
+				// TODO: WOULD BE GOOD IF THIS COULD BE MOVED TO app.go
+				// pm.pollQueueDebugMsg(fmt.Sprintf("pm.marshaller: %+v", pm.marshaller))
+				point, err = pm.marshaller.UpdatePoint(point.UUID, point)
+				if err != nil || point == nil {
+					pm.pollQueueErrorMsg(fmt.Sprintf("point DB UPDATE FAILED Err: %+v", err))
+					return
+				}
+				// pm.pollQueueDebugMsg(fmt.Sprintf("point after DB UPDATE: %+v", point))
+				// printPointDebugInfo(point)
+			}
+		*/
+	}
+	return f
+}
+
+func (pm *NetworkPollManager) MakeLockupTimerFunc(priority model.PollPriority) *time.Timer {
+	timeoutDuration := 5 * time.Minute
+
+	switch priority {
+	case model.PRIORITY_ASAP:
+		timeoutDuration = pm.ASAPPriorityMaxCycleTime
+
+	case model.PRIORITY_HIGH:
+		timeoutDuration = pm.HighPriorityMaxCycleTime
+
+	case model.PRIORITY_NORMAL:
+		timeoutDuration = pm.NormalPriorityMaxCycleTime
+
+	case model.PRIORITY_LOW:
+		timeoutDuration = pm.LowPriorityMaxCycleTime
+
+	}
+
+	f := func() {
+		pm.pollQueueDebugMsg("Polling Lockout Timer Expired! Polling Priority: %d,  Polling Network: %s", priority, pm.FFNetworkUUID)
+		plugin, err := pm.Marshaller.GetPlugin(pm.FFPluginUUID, "")
+		switch priority {
+		case model.PRIORITY_ASAP:
+			pm.ASAPPriorityLockupAlert = true
+			if plugin != nil && err == nil {
+				pm.pollQueueErrorMsg(fmt.Sprintf("%s Plugin: ASAP Priority Poll Queue LOCKUP", plugin.Name))
+			} else {
+				pm.pollQueueErrorMsg("Unknown Plugin: ASAP Priority Poll Queue LOCKUP")
+			}
+			// TODO: update network error to show queue lockup
+
+		case model.PRIORITY_HIGH:
+			pm.HighPriorityLockupAlert = true
+			if plugin != nil && err == nil {
+				pm.pollQueueErrorMsg(fmt.Sprintf("%s Plugin: HIGH Priority Poll Queue LOCKUP", plugin.Name))
+			} else {
+				pm.pollQueueErrorMsg("Unknown Plugin: HIGH Priority Poll Queue LOCKUP")
+			}
+			// TODO: update network error to show queue lockup
+
+		case model.PRIORITY_NORMAL:
+			pm.NormalPriorityLockupAlert = true
+			if plugin != nil && err == nil {
+				pm.pollQueueErrorMsg(fmt.Sprintf("%s Plugin: NORMAL Priority Poll Queue LOCKUP", plugin.Name))
+			} else {
+				pm.pollQueueErrorMsg("Unknown Plugin: NORMAL Priority Poll Queue LOCKUP")
+			}
+			// TODO: update network error to show queue lockup
+
+		case model.PRIORITY_LOW:
+			pm.LowPriorityLockupAlert = true
+			if plugin != nil && err == nil {
+				pm.pollQueueErrorMsg(fmt.Sprintf("%s Plugin: LOW Priority Poll Queue LOCKUP", plugin.Name))
+			} else {
+				pm.pollQueueErrorMsg("Unknown Plugin: LOW Priority Poll Queue LOCKUP")
+			}
+			// TODO: update network error to show queue lockup
+
+		}
+	}
+	return time.AfterFunc(timeoutDuration, f)
+}
+
+func (pm *NetworkPollManager) SetPointPollRequiredFlagsBasedOnWriteMode(point *model.Point) {
+
+	if point == nil {
+		pm.pollQueueDebugMsg("NetworkPollManager.SetPointPollRequiredFlagsBasedOnWriteMode(): couldn't find point")
+		return
+	}
+
+	switch point.WriteMode {
+	case model.ReadOnce:
+		return
+
+	case model.ReadOnly: // ReadOnly          Re-add with ReadPollRequired true, WritePollRequired false.
+		point.ReadPollRequired = boolean.NewTrue()
+		point.WritePollRequired = boolean.NewFalse()
+
+	case model.WriteOnce: // WriteOnce         If write_successful then don't re-add.
+		return
+
+	case model.WriteOnceReadOnce: // WriteOnceReadOnce     If write_successful and read_success then don't re-add.
+		return
+
+	case model.WriteAlways: // WriteAlways       Re-add with ReadPollRequired false, WritePollRequired true. confirm that a successful write ensures the value is set to the write value.
+		point.ReadPollRequired = boolean.NewFalse()
+		point.WritePollRequired = boolean.NewTrue()
+
+	case model.WriteOnceThenRead: // WriteOnceThenRead     If write_successful: Re-add with ReadPollRequired true, WritePollRequired false.
+		point.ReadPollRequired = boolean.NewTrue()
+		point.WritePollRequired = boolean.NewTrue()
+
+	case model.WriteAndMaintain: // WriteAndMaintain    If write_successful: Re-add with ReadPollRequired true, WritePollRequired false.  Need to check that write value matches present value after each read poll.
+		point.ReadPollRequired = boolean.NewTrue()
+		point.WritePollRequired = boolean.NewTrue()
+	}
+
+	pm.Marshaller.UpdatePoint(point.UUID, point)
+}

--- a/module/shared/pollqueue/queue_unloader.go
+++ b/module/shared/pollqueue/queue_unloader.go
@@ -1,0 +1,109 @@
+package pollqueue
+
+import (
+	"fmt"
+	"github.com/NubeIO/rubix-os/utils/float"
+	"time"
+	// log "github.com/sirupsen/logrus"
+)
+
+// REFS:
+//  - GOLANG HEAP https://pkg.go.dev/container/heap
+//  - Worker Queue tutorial: https://www.opsdash.com/blog/job-queues-in-go.html
+
+type QueueUnloader struct {
+	NextPollPoint *PollingPoint
+	// NextUnloadTimer 		*time.Timer
+	NextUnloadTimer *time.Ticker
+	CancelChannel   chan bool
+}
+
+func (pm *NetworkPollManager) StartQueueUnloader() {
+	pm.StopQueueUnloader()
+	ql := &QueueUnloader{nil, nil, nil}
+	pm.PluginQueueUnloader = ql
+	if pm.PluginQueueUnloader.NextPollPoint == nil {
+		pm.postNextPointCallback()
+		/*
+			pm.pollQueueDebugMsg("StartQueueUnloader() pm.PluginQueueUnloader.NextPollPoint == nil")
+			pp, err := pm.PollQueue.GetNextPollingPoint()
+			if pp != nil && err == nil {
+				pm.PluginQueueUnloader.NextPollPoint = pp
+			}
+
+		*/
+	}
+
+	refreshRate := 100 * time.Millisecond // Default MaxPollRate
+	if pm.Marshaller != nil {
+		// var netArg api.Args
+		net, err := pm.Marshaller.GetNetwork(pm.FFNetworkUUID, "")
+		if err != nil {
+			pm.pollQueueDebugMsg(fmt.Sprintf("NetworkPollManager.StartQueueUnloader(): couldn't find network %s", pm.FFNetworkUUID))
+			return
+		}
+		if float.NonNil(net.MaxPollRate) > 0 {
+			refreshRate, _ = time.ParseDuration(fmt.Sprintf("%fs", float.NonNil(net.MaxPollRate)))
+			pm.pollQueueDebugMsg(fmt.Sprintf("NetworkPollManager.StartQueueUnloader(): net.MaxPollRate %f ", float.NonNil(net.MaxPollRate)))
+		}
+	} else {
+		pm.pollQueueErrorMsg("StartQueueUnloader(): NetworkPollManager marshaller is undefined")
+	}
+
+	pm.MaxPollRate = refreshRate
+	ticker := time.NewTicker(refreshRate)
+	pm.PluginQueueUnloader.NextUnloadTimer = ticker
+	done := make(chan bool)
+	pm.PluginQueueUnloader.CancelChannel = done
+
+	go func() {
+		for {
+			select {
+			case <-done:
+				return
+			case <-ticker.C:
+				// pm.pollQueueDebugMsg("RELOAD QUEUE TICKER")
+				pm.postNextPointCallback()
+			}
+		}
+	}()
+}
+
+func (pm *NetworkPollManager) StopQueueUnloader() {
+	pm.pollQueueDebugMsg("StopQueueUnloader()")
+	if pm.PluginQueueUnloader != nil && pm.PluginQueueUnloader.NextUnloadTimer != nil && pm.PluginQueueUnloader.CancelChannel != nil {
+		pm.PluginQueueUnloader.NextUnloadTimer.Stop()
+		pm.PluginQueueUnloader.NextUnloadTimer = nil
+		pm.PluginQueueUnloader.CancelChannel <- true
+		pm.PluginQueueUnloader.CancelChannel = nil
+		pm.pollQueueDebugMsg("StopQueueUnloader() NextUnloadTimer stopped and CancelChannel closed")
+	}
+	pm.PluginQueueUnloader = nil
+}
+
+// GetNextPollingPoint This function should be called from the Polling service.
+func (pm *NetworkPollManager) GetNextPollingPoint() (pp *PollingPoint, callback func(pp *PollingPoint, writeSuccess, readSuccess bool, pollTimeSecs float64, pointUpdate, resetToConfiguredPriority bool, retryType PollRetryType, actualPoll, pollingWasNotRequired, justToReAdd bool)) {
+	if pm.PluginQueueUnloader != nil && pm.PluginQueueUnloader.NextPollPoint != nil {
+		pp := pm.PluginQueueUnloader.NextPollPoint
+		pm.PluginQueueUnloader.NextPollPoint = nil
+		// Moving the line below to a reoccurring timer instead.
+		// pm.PluginQueueUnloader.NextUnloadTimer = time.AfterFunc(pm.MaxPollRate, pm.postNextPointCallback)
+		return pp, pm.PollingPointCompleteNotification
+	}
+	// pm.pollQueueDebugMsg("GetNextPollingPoint(): No pollingPoint available")
+	return nil, nil
+}
+
+// This is the callback function that is called by the reoccurring timer (seperate go routine) made in StartQueueUnloader().
+func (pm *NetworkPollManager) postNextPointCallback() {
+	if pm.PluginQueueUnloader != nil && pm.PluginQueueUnloader.NextPollPoint == nil {
+		pp, err := pm.PollQueue.GetNextPollingPoint()
+		if pp != nil && err == nil {
+			pm.PluginQueueUnloader.NextPollPoint = pp
+			addSuccess := pm.PollQueue.OutstandingPollingPoints.AddPollingPoint(pp)
+			if !addSuccess {
+				pm.pollQueueErrorMsg(fmt.Sprintf("Modbus postNextPointCallback(): polling point could not be added to OutstandingPollingPoints slice.  (%s)", pp.FFPointUUID))
+			}
+		}
+	}
+}


### PR DESCRIPTION
This uses marshaller to communicate with necessary endpoints instead of directly calling dbHelper.