### PR TITLE
Add host_uuid and point_uuid args in network,device and point

### DIFF
--- a/api/args.go
+++ b/api/args.go
@@ -49,6 +49,8 @@ type Args struct {
 	MetaTags          *string
 	MemberUUID        *string
 	ShowCloneNetworks bool
+	PointSourceUUID   *string
+	HostUUID          *string
 }
 
 var ArgsType = struct {
@@ -98,6 +100,8 @@ var ArgsType = struct {
 	WithMetaTags      string
 	MetaTags          string
 	ShowCloneNetworks string
+	PointSourceUUID   string
+	HostUUID          string
 }{
 	Sort:              "sort",
 	Order:             "order",
@@ -145,6 +149,8 @@ var ArgsType = struct {
 	WithMetaTags:      "with_meta_tags",
 	MetaTags:          "meta_tags",
 	ShowCloneNetworks: "show_clone_networks",
+	PointSourceUUID:   "point_source_uuid",
+	HostUUID:          "host_uuid",
 }
 
 var ArgsDefault = struct {

--- a/api/args_builder.go
+++ b/api/args_builder.go
@@ -16,6 +16,12 @@ func buildNetworkArgs(ctx *gin.Context) Args {
 		args.MetaTags = &value
 	}
 	args.ShowCloneNetworks, _ = toBool(ctx.DefaultQuery(aType.ShowCloneNetworks, aDefault.ShowCloneNetworks))
+	if value, ok := ctx.GetQuery(aType.PointSourceUUID); ok {
+		args.PointSourceUUID = &value
+	}
+	if value, ok := ctx.GetQuery(aType.HostUUID); ok {
+		args.HostUUID = &value
+	}
 	return args
 }
 
@@ -32,6 +38,12 @@ func buildDeviceArgs(ctx *gin.Context) Args {
 	}
 	if value, ok := ctx.GetQuery(aType.MetaTags); ok {
 		args.MetaTags = &value
+	}
+	if value, ok := ctx.GetQuery(aType.PointSourceUUID); ok {
+		args.PointSourceUUID = &value
+	}
+	if value, ok := ctx.GetQuery(aType.HostUUID); ok {
+		args.HostUUID = &value
 	}
 	return args
 }
@@ -57,6 +69,12 @@ func buildPointArgs(ctx *gin.Context) Args {
 	}
 	if value, ok := ctx.GetQuery(aType.MetaTags); ok {
 		args.MetaTags = &value
+	}
+	if value, ok := ctx.GetQuery(aType.PointSourceUUID); ok {
+		args.PointSourceUUID = &value
+	}
+	if value, ok := ctx.GetQuery(aType.HostUUID); ok {
+		args.HostUUID = &value
 	}
 	return args
 }

--- a/src/dbhandler/devices.go
+++ b/src/dbhandler/devices.go
@@ -83,3 +83,7 @@ func (h *Handler) ClearErrorsForAllPointsOnDevice(networkUUID string) error {
 func (h *Handler) GetDevicesTagsForPostgresSync() ([]*interfaces.DeviceTagForPostgresSync, error) {
 	return getDb().GetDevicesTagsForPostgresSync()
 }
+
+func (h *Handler) GetOneDeviceByArgs(args api.Args) (*model.Device, error) {
+	return getDb().GetOneDeviceByArgs(args)
+}

--- a/src/dbhandler/networks.go
+++ b/src/dbhandler/networks.go
@@ -110,3 +110,7 @@ func (h *Handler) ClearErrorsForAllDevicesOnNetwork(networkUUID string, doPoints
 func (h *Handler) GetNetworksTagsForPostgresSync() ([]*interfaces.NetworkTagForPostgresSync, error) {
 	return getDb().GetNetworksTagsForPostgresSync()
 }
+
+func (h *Handler) GetOneNetworkByArgs(args api.Args) (*model.Network, error) {
+	return getDb().GetOneNetworkByArgs(args)
+}


### PR DESCRIPTION
Resolves: #76 
### Summary:
- Added `point_source_uuid` and `host_uuid` args in network,device and point endpoints. Examples:
  - API query params `?point_source_uuid=<point_uuid>&host_uuid=<host_uuid>`
  - `dbhandler` functions calls examples:
    - ```
       args := api.Args {
                   PointSourceUUID: "point_uuid",
                   HostUUID:"host_uuid",
                   MetaTags:true,
                   WithMetaTags:true,
              }
      ```
    - `inst.db.GetOneNetworkByArgs(args)`
    - `inst.db.GetOneDeviceByArgs(args)`
    - `inst.db.GetOnePointByArgs(args)`