### PR TITLE
Create point history if point write value change is greater than or equal to HistoryCOVThreshold

### DIFF
--- a/api/points.go
+++ b/api/points.go
@@ -14,7 +14,7 @@ type PointDatabase interface {
 	GetPoint(uuid string, args Args) (*model.Point, error)
 	CreatePoint(body *model.Point) (*model.Point, error)
 	UpdatePoint(uuid string, body *model.Point) (*model.Point, error)
-	PointWrite(uuid string, body *model.PointWriter, forceWrite bool) (*model.Point, bool, bool, bool, error)
+	PointWrite(uuid string, body *model.PointWriter) (*model.Point, bool, bool, bool, error)
 	GetOnePointByArgs(args Args) (*model.Point, error)
 	DeletePoint(uuid string) (bool, error)
 	GetPointByName(networkName, deviceName, pointName string, args Args) (*model.Point, error)

--- a/database/point_funcs.go
+++ b/database/point_funcs.go
@@ -89,6 +89,13 @@ func priorityMapToPatch(priorityMap *map[string]*float64) map[string]interface{}
 	return priorityMapToPatch_
 }
 
+func defaultHistoryCOVThreshold(b *float64) *float64 {
+	if b == nil {
+		return float.New(0.01)
+	}
+	return b
+}
+
 func (d *GormDatabase) GetPointsForPostgresSync() ([]*interfaces.PointForPostgresSync, error) {
 	var pointsForPostgresModel []*interfaces.PointForPostgresSync
 	query := d.DB.Table("points").

--- a/database/point_plugin.go
+++ b/database/point_plugin.go
@@ -103,7 +103,7 @@ func (d *GormDatabase) WritePointPlugin(uuid string, body *model.PointWriter) (p
 	}
 	pluginName := network.PluginPath
 	if pluginName == "system" || pluginName == "module-core-system" {
-		point, _, _, _, err = d.PointWrite(uuid, body, false)
+		point, _, _, _, err = d.PointWrite(uuid, body)
 		if err != nil {
 			return nil, err
 		}

--- a/module/dbhelper.go
+++ b/module/dbhelper.go
@@ -154,7 +154,7 @@ func (*dbHelper) Patch(path, uuid string, body []byte) ([]byte, error) {
 			log.Error(err)
 			return nil, err
 		}
-		point, isPresentValueChange, isWriteValueChange, isPriorityChanged, err := database.GlobalGormDatabase.PointWrite(uuid, &pw, false)
+		point, isPresentValueChange, isWriteValueChange, isPriorityChanged, err := database.GlobalGormDatabase.PointWrite(uuid, &pw)
 		if err != nil {
 			return nil, err
 		}

--- a/schema/bacnetschema/point.go
+++ b/schema/bacnetschema/point.go
@@ -31,9 +31,10 @@ type PointSchema struct {
 	Decimal  schema.Decimal  `json:"decimal"`
 	Fallback schema.Fallback `json:"fallback"`
 
-	HistoryEnable   schema.HistoryEnableDefaultTrue `json:"history_enable"`
-	HistoryType     schema.HistoryType              `json:"history_type"`
-	HistoryInterval schema.HistoryInterval          `json:"history_interval"`
+	HistoryEnable       schema.HistoryEnableDefaultTrue `json:"history_enable"`
+	HistoryType         schema.HistoryType              `json:"history_type"`
+	HistoryInterval     schema.HistoryInterval          `json:"history_interval"`
+	HistoryCOVThreshold schema.HistoryCOVThreshold      `json:"history_cov_threshold"`
 }
 
 func GetPointSchema() *PointSchema {

--- a/schema/edge28schema/point.go
+++ b/schema/edge28schema/point.go
@@ -48,9 +48,10 @@ type PointSchema struct {
 	Decimal              schema.Decimal              `json:"decimal"`
 	Fallback             schema.Fallback             `json:"fallback"`
 
-	HistoryEnable   schema.HistoryEnableDefaultTrue `json:"history_enable"`
-	HistoryType     schema.HistoryType              `json:"history_type"`
-	HistoryInterval schema.HistoryInterval          `json:"history_interval"`
+	HistoryEnable       schema.HistoryEnableDefaultTrue `json:"history_enable"`
+	HistoryType         schema.HistoryType              `json:"history_type"`
+	HistoryInterval     schema.HistoryInterval          `json:"history_interval"`
+	HistoryCOVThreshold schema.HistoryCOVThreshold      `json:"history_cov_threshold"`
 }
 
 func GetPointSchema() *PointSchema {

--- a/schema/loraschema/point.go
+++ b/schema/loraschema/point.go
@@ -20,9 +20,10 @@ type PointSchema struct {
 	Decimal              schema.Decimal              `json:"decimal"`
 	Fallback             schema.Fallback             `json:"fallback"`
 
-	HistoryEnable   schema.HistoryEnableDefaultTrue `json:"history_enable"`
-	HistoryType     schema.HistoryType              `json:"history_type"`
-	HistoryInterval schema.HistoryInterval          `json:"history_interval"`
+	HistoryEnable       schema.HistoryEnableDefaultTrue `json:"history_enable"`
+	HistoryType         schema.HistoryType              `json:"history_type"`
+	HistoryInterval     schema.HistoryInterval          `json:"history_interval"`
+	HistoryCOVThreshold schema.HistoryCOVThreshold      `json:"history_cov_threshold"`
 }
 
 func GetPointSchema() *PointSchema {

--- a/schema/lorawanschema/point.go
+++ b/schema/lorawanschema/point.go
@@ -18,9 +18,10 @@ type PointSchema struct {
 	Decimal              schema.Decimal              `json:"decimal"`
 	Fallback             schema.Fallback             `json:"fallback"`
 
-	HistoryEnable   schema.HistoryEnableDefaultTrue `json:"history_enable"`
-	HistoryType     schema.HistoryType              `json:"history_type"`
-	HistoryInterval schema.HistoryInterval          `json:"history_interval"`
+	HistoryEnable       schema.HistoryEnableDefaultTrue `json:"history_enable"`
+	HistoryType         schema.HistoryType              `json:"history_type"`
+	HistoryInterval     schema.HistoryInterval          `json:"history_interval"`
+	HistoryCOVThreshold schema.HistoryCOVThreshold      `json:"history_cov_threshold"`
 }
 
 func GetPointSchema() *PointSchema {

--- a/schema/masterschema/point.go
+++ b/schema/masterschema/point.go
@@ -25,9 +25,10 @@ type PointSchema struct {
 	Decimal              schema.Decimal              `json:"decimal"`
 	Fallback             schema.Fallback             `json:"fallback"`
 
-	HistoryEnable   schema.HistoryEnableDefaultTrue `json:"history_enable"`
-	HistoryType     schema.HistoryType              `json:"history_type"`
-	HistoryInterval schema.HistoryInterval          `json:"history_interval"`
+	HistoryEnable       schema.HistoryEnableDefaultTrue `json:"history_enable"`
+	HistoryType         schema.HistoryType              `json:"history_type"`
+	HistoryInterval     schema.HistoryInterval          `json:"history_interval"`
+	HistoryCOVThreshold schema.HistoryCOVThreshold      `json:"history_cov_threshold"`
 }
 
 func GetPointSchema() *PointSchema {

--- a/schema/modbuschema/point.go
+++ b/schema/modbuschema/point.go
@@ -28,9 +28,10 @@ type PointSchema struct {
 	Decimal              schema.Decimal              `json:"decimal"`
 	Fallback             schema.Fallback             `json:"fallback"`
 
-	HistoryEnable   schema.HistoryEnableDefaultTrue `json:"history_enable"`
-	HistoryType     schema.HistoryType              `json:"history_type"`
-	HistoryInterval schema.HistoryInterval          `json:"history_interval"`
+	HistoryEnable       schema.HistoryEnableDefaultTrue `json:"history_enable"`
+	HistoryType         schema.HistoryType              `json:"history_type"`
+	HistoryInterval     schema.HistoryInterval          `json:"history_interval"`
+	HistoryCOVThreshold schema.HistoryCOVThreshold      `json:"history_cov_threshold"`
 }
 
 func GetPointSchema() *PointSchema {

--- a/schema/networklinkerschema/point.go
+++ b/schema/networklinkerschema/point.go
@@ -47,9 +47,10 @@ type PointSchema struct {
 	Decimal              schema.Decimal              `json:"decimal"`
 	Fallback             schema.Fallback             `json:"fallback"`
 
-	HistoryEnable   schema.HistoryEnableDefaultTrue `json:"history_enable"`
-	HistoryType     schema.HistoryType              `json:"history_type"`
-	HistoryInterval schema.HistoryInterval          `json:"history_interval"`
+	HistoryEnable       schema.HistoryEnableDefaultTrue `json:"history_enable"`
+	HistoryType         schema.HistoryType              `json:"history_type"`
+	HistoryInterval     schema.HistoryInterval          `json:"history_interval"`
+	HistoryCOVThreshold schema.HistoryCOVThreshold      `json:"history_cov_threshold"`
 }
 
 func GetPointSchema() *PointSchema {

--- a/schema/rubixioschema/point.go
+++ b/schema/rubixioschema/point.go
@@ -47,9 +47,10 @@ type PointSchema struct {
 	Decimal              schema.Decimal              `json:"decimal"`
 	Fallback             schema.Fallback             `json:"fallback"`
 
-	HistoryEnable   schema.HistoryEnableDefaultTrue `json:"history_enable"`
-	HistoryType     schema.HistoryType              `json:"history_type"`
-	HistoryInterval schema.HistoryInterval          `json:"history_interval"`
+	HistoryEnable       schema.HistoryEnableDefaultTrue `json:"history_enable"`
+	HistoryType         schema.HistoryType              `json:"history_type"`
+	HistoryInterval     schema.HistoryInterval          `json:"history_interval"`
+	HistoryCOVThreshold schema.HistoryCOVThreshold      `json:"history_cov_threshold"`
 }
 
 func GetPointSchema() *PointSchema {

--- a/schema/schema/point.go
+++ b/schema/schema/point.go
@@ -134,3 +134,9 @@ type HistoryInterval struct {
 	Title   string `json:"title" default:"History Interval"`
 	Default *int   `json:"default" default:"15"`
 }
+
+type HistoryCOVThreshold struct {
+	Type    string   `json:"type" default:"number"`
+	Title   string   `json:"title" default:"History COV Threshold"`
+	Default *float64 `json:"default" default:"0.01"`
+}

--- a/schema/systemschema/point.go
+++ b/schema/systemschema/point.go
@@ -18,9 +18,10 @@ type PointSchema struct {
 	Decimal              schema.Decimal              `json:"decimal"`
 	Fallback             schema.Fallback             `json:"fallback"`
 
-	HistoryEnable   schema.HistoryEnableDefaultTrue `json:"history_enable"`
-	HistoryType     schema.HistoryType              `json:"history_type"`
-	HistoryInterval schema.HistoryInterval          `json:"history_interval"`
+	HistoryEnable       schema.HistoryEnableDefaultTrue `json:"history_enable"`
+	HistoryType         schema.HistoryType              `json:"history_type"`
+	HistoryInterval     schema.HistoryInterval          `json:"history_interval"`
+	HistoryCOVThreshold schema.HistoryCOVThreshold      `json:"history_cov_threshold"`
 }
 
 func GetPointSchema() *PointSchema {

--- a/src/dbhandler/points.go
+++ b/src/dbhandler/points.go
@@ -49,7 +49,7 @@ func (h *Handler) UpdatePointPlugin(uuid string, body *model.Point) (*model.Poin
 
 func (h *Handler) PointWrite(uuid string, pointWriter *model.PointWriter) (
 	returnPoint *model.Point, isPresentValueChange, isWriteValueChange, isPriorityChanged bool, err error) {
-	return getDb().PointWrite(uuid, pointWriter, false)
+	return getDb().PointWrite(uuid, pointWriter)
 }
 
 // UpdatePointErrors will only update the error properties of the point, all other properties will not be updated.


### PR DESCRIPTION
Resolves: #39 
### Summary:
- Set `HistoryCovThreshold` default value to 0.01.
- Added cov condition to check if point write value change is greater than or equal to HistoryCOVThreshold before creating point history.